### PR TITLE
Fix links in Amazon Seller Central, BigCommerce, Chargebee, and Chargify sections

### DIFF
--- a/docs/integrations/commerce/amazon-seller-central/amazon-registration-steps.md
+++ b/docs/integrations/commerce/amazon-seller-central/amazon-registration-steps.md
@@ -73,7 +73,7 @@ If you lose your AWS secret access key you will need to create a new IAM user wi
 7. Under "OAuth Redirect URI" enter `https://amazonsellercentral.codat.io/oauth/callback`
 8. Click Save and Exit
 
-Before you can link an Amazon company in your Codat environment, you must submit your Amazon Seller Central app for listing in the Marketplace. Apps must be reviewed and approved by Amazon, which may take up to two weeks. For more details, see [Using Amazon Seller Central apps in production](/amazon-registration-steps#using-amazon-seller-central-apps-in-production), below.
+Before you can link an Amazon company in your Codat environment, you must submit your Amazon Seller Central app for listing in the Marketplace. Apps must be reviewed and approved by Amazon, which may take up to two weeks. For more details, see the next task.
 
 ## Using Amazon Seller Central Apps to access Live Data
 

--- a/docs/integrations/commerce/amazon-seller-central/commerce-amazon-seller-central.md
+++ b/docs/integrations/commerce/amazon-seller-central/commerce-amazon-seller-central.md
@@ -5,9 +5,7 @@ createdAt: "2021-08-27T22:41:15.062Z"
 updatedAt: "2022-10-20T13:32:18.005Z"
 ---
 
-<a class="external" href="https://sellercentral.amazon.com/" target="_blank">
-  Amazon Seller Central
-</a> is a platform that independent merchants use to sell their products on Amazon.
+<a class="external" href="https://sellercentral.amazon.com/" target="_blank">Amazon Seller Central</a> is a platform that independent merchants use to sell their products on Amazon.
 
 Our Commerce API supports Amazon Seller Central and allows your linked customers to share their Amazon Seller Central data through Codat. You can then retrieve this data in the same standardized format as our other commerce integrations.
 
@@ -17,12 +15,14 @@ View the coverage of our Amazon Seller Central integration in the <a className="
 
 ## Set up the integration
 
-See [Set up the Amazon Seller Central Integration](/set-up-amazon-seller-central) to learn how to set up and enable the integration.
+See [Set up the Amazon Seller Central Integration](/integrations/commerce/amazon-seller-central/set-up-amazon-seller-central) to learn how to set up and enable the integration.
 
 :::caution Underlying provider requirements
-Before setting up your Amazon Seller Central integration, you must complete all the requirements described in [Amazon Web Services, IAM & Developer Registration](/amazon-registration-steps).
+
+Before setting up your Amazon Seller Central integration, you must complete all the requirements described in [Amazon Web Services, IAM & Developer Registration](/integrations/commerce/amazon-seller-central/amazon-registration-steps).
 
 Note that your application must be reviewed before you can start using the integration.
+
 :::
 
 ## Important definitions
@@ -36,11 +36,15 @@ Both in general and in this documentation, Codat refers to our Amazon integratio
 For the sake of clarity when discussing developer registration in particular, this guide will use the exact name of the API.
 
 :::caution Rate Limits and Sync Frequency
+
 The Selling Partner API enforces rate limiting on incoming requests. Effectively, these limits work out to allowing [1 request per minute](https://developer-docs.amazon.com/sp-api/docs/orders-api-v0-reference#get-ordersv0orders). Syncing commerce data at a high frequency &ndash; for example, once every 15 minutes &ndash; will likely exceed the rate limit and cause poor performance due to throttled requests. For optimal performance, we recommend setting the sync frequency of the Amazon Seller Central integration to a long interval, such as daily or weekly.
+
 :::
 
 :::caution Multiple Marketplaces
+
 Amazon Seller Central is a global platform with separate marketplaces in separate territories around the world. While merchants can sell in multiple marketplaces, each data connection is limited to a single marketplace being served by the Amazon merchant.
 
 Your customers who sell in multiple territories can connect all their Amazon Seller Central marketplaces to Codat, but will need to go through the Link flow separately for each regional marketplace.
+
 :::

--- a/docs/integrations/commerce/amazon-seller-central/set-up-amazon-seller-central.md
+++ b/docs/integrations/commerce/amazon-seller-central/set-up-amazon-seller-central.md
@@ -7,7 +7,7 @@ updatedAt: "2023-01-06T16:30:35.075Z"
 
 Before you can pull commerce data from merchants using Amazon Seller Central, you need to set up the integration in Codat's environments.
 
-Before you begin, you will need to have completed all of the prerequisite setup instructions [here](/amazon-registration-steps) to have setup your Amazon AWS and Seller Central credentials.
+Before you begin, you will need to have completed all of the prerequisite setup instructions [here](/integrations/commerce/amazon-seller-central/amazon-registration-steps) to have setup your Amazon AWS and Seller Central credentials.
 
 ## Retrieving your secure credentials
 
@@ -23,7 +23,7 @@ Before you begin, you will need to have completed all of the prerequisite setup 
 ![](https://files.readme.io/43ea65f-ASC.png "ASC.png")
 
 6. Copy the AWS Access Key and Secret Access Key from the relevant IAM User Profile and paste into AWS access key and AWS secret access key fields in the Codat Portal.
-   - This includes the key you downloaded when [creating your IAM User](/amazon-registration-steps)
+   - This includes the key you downloaded when [creating your IAM User](/integrations/commerce/amazon-seller-central/amazon-registration-steps)
 7. In the Codat Portal, click **Save**.
 
 ## Enable the Amazon Seller Central integration
@@ -35,4 +35,4 @@ You can also click **Manage** to view the integration's settings page, and then 
 
 ## Check your Sync Settings in the Codat Portal
 
-If this is your first commerce integration, update your [data type settings](/commerce-sync-settings) to enable commerce data types.
+If this is your first commerce integration, update your [data type settings](/core-concepts/data-type-settings) to enable commerce data types.

--- a/docs/integrations/commerce/api-workflow.md
+++ b/docs/integrations/commerce/api-workflow.md
@@ -12,22 +12,22 @@ After you've set up an integration, follow this process to use Codat's API to en
 
 ## Enable and update commerce sync settings
 
-Update your [commerce sync settings](/commerce-sync-settings#section-update-commerce-sync-settings-via-the-api) to automatically retrieve data from a company when they authorise your connection to their data.
+Update your [commerce sync settings](/integrations/commerce/commerce-sync-settings#update-commerce-sync-settings-via-the-api) to automatically retrieve data from a company when they authorise your connection to their data.
 
 ## Create a company and data connection
 
 Create a Codat company and data connection for your customer.
 
-1. Open the [POST /companies](https://api.codat.io/swagger/index.html#/Companies/post_companies) endpoint.
+1. Open the [Create a company](/codat-api#/operations/create-company) endpoint.
 2. Enter a **companyName** and **platformType** and submit your request.
    The response returned includes:
-
-- The **linkUrl** which allows your customer to authorise your connection to their data.
-- The data connection **id** which allows you to sync the company's data.
+   
+   - The **linkUrl** which allows your customer to authorise your connection to their data.
+   - The data connection **id** which allows you to sync the company's data.
 
 3. Copy the **linkUrl** and send it to your customer.
 
-```
+```json
 {
 "name": "john",
 "platformType": "woocommerce",
@@ -35,7 +35,7 @@ Create a Codat company and data connection for your customer.
 }
 ```
 
-```
+```json
 {
 "id": "fc0043b0-8c40-4c5b-b92f-f155cb720451",
 "name": "john",
@@ -63,14 +63,20 @@ Create a Codat company and data connection for your customer.
 When your customer authorises your connection to their company data, Codat automatically fetches their datasets. You can pull these datasets from the following endpoints. Use the company and data connection **id** that you've already created. See above.
 
 `GET /companies/{{companyId}}/connections/{{connectionId}}/data/commerce-customers`
+
 `GET /.../commerce-disputes`
+
 `GET /.../commerce-info`
+
 `GET /.../commerce-orders`
+
 `GET /.../commerce-payments`
+
 `GET /.../commerce-products`
+
 `GET /.../commerce-transactions`
 
 :::info Sync status
 
-Before you can view data using one of the commerce endpoints, you must wait for the data synchronisation to complete. To check the status of any dataset, see the [sync status](/data-status) documentation.
+Before you can view data using one of the commerce endpoints, you must wait for the data synchronisation to complete. To check the status of any dataset, see the [sync status](/core-concepts/status) documentation.
 :::

--- a/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-test.md
+++ b/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-test.md
@@ -11,7 +11,7 @@ You can view the sample commerce data in the Codat Portal.
 
 ## Prerequisites
 
-- Update your [data type settings](/commerce-sync-settings) to enable commerce data types.
+- Update your [data type settings](/integrations/commerce/commerce-sync-settings) to enable commerce data types.
 
 ## Add a test company
 
@@ -37,7 +37,7 @@ In the <a className="external" href="https://app.codat.io" target="_blank">Codat
 1. Click **Companies** then locate the test company you created.
 2. Click the **Link** icon next to the test company.
 3. Enter the Link URL in a new browser tab.
-4. Follow the steps in [SMB customer: Authenticate and connect your commerce data](/commerce-bigcommerce-setup#smb-customer-authenticate-and-connect-your-commerce-data).
+4. Follow the steps in [SMB customer: Authenticate and connect your commerce data](/integrations/commerce/bigcommerce/commerce-bigcommerce-setup#smb-customer-authenticate-and-connect-your-commerce-data).
 
 ## Retrieve sample commerce data
 

--- a/docs/integrations/commerce/bigcommerce/commerce-bigcommerce.md
+++ b/docs/integrations/commerce/bigcommerce/commerce-bigcommerce.md
@@ -5,9 +5,7 @@ createdAt: "2022-07-18T14:09:10.776Z"
 updatedAt: "2022-10-20T13:32:45.801Z"
 ---
 
-<a className="external" href="https://www.bigcommerce.com/" target="_blank">
-  BigCommerce
-</a> is a SaaS-based ecommerce platform for retailers of various sizes, both B2C
+<a className="external" href="https://www.bigcommerce.com/" target="_blank">BigCommerce</a> is a SaaS-based ecommerce platform for retailers of various sizes, both B2C
 and B2B.
 
 With Codat's BigCommerce integration, you can securely connect to, retrieve, and view your SMB customers' commerce transactions from BigCommerce. Data is standardized to our data model and available through our [Commerce API](/data-model/commerce/).
@@ -16,26 +14,14 @@ With Codat's BigCommerce integration, you can securely connect to, retrieve, and
 
 View the coverage of our BigCommerce integration in the <a className="external" href="https://knowledge.codat.io/supported-features/commerce?view=tab-by-integration&integrationKey=vqzp" target="_blank">Data coverage explorer</a>.
 
-For more information about the supported data types, see [BigCommerce integration reference](/commerce-bigcommerce-integration-reference).
+For more information about the supported data types, see [BigCommerce integration reference](/integrations/commerce/bigcommerce/commerce-bigcommerce-integration-reference).
 
 ## Sandbox stores
 
-Before sending Link URLs to your SMB customers, we recommend that you [test the integration](/commerce-bigcommerce-test) using sample data from a sandbox store. You must be a Technology Partner to create a sandbox store and add sample data to it. For more information, refer to the following articles in the BigCommerce Dev Center:
+Before sending Link URLs to your SMB customers, we recommend that you [test the integration](/integrations/commerce/bigcommerce/commerce-bigcommerce-test) using sample data from a sandbox store. You must be a Technology Partner to create a sandbox store and add sample data to it. For more information, refer to the following articles in the BigCommerce Dev Center:
 
-- <a
-    className="external"
-    href="https://developer.bigcommerce.com/docs/ZG9jOjIyMDYxOQ-becoming-a-partner"
-    target="_blank"
-  >
-    Becoming a Partner
-  </a>
-- <a
-    className="external"
-    href="https://developer.bigcommerce.com/docs/ZG9jOjM4MzMyNTE-create-a-sandbox-store"
-    target="_blank"
-  >
-    Create a Sandbox Store
-  </a>
+- <a className="external" href="https://developer.bigcommerce.com/docs/ZG9jOjIyMDYxOQ-becoming-a-partner" target="_blank">Becoming a Partner</a>
+- <a className="external" href="https://developer.bigcommerce.com/docs/ZG9jOjM4MzMyNTE-create-a-sandbox-store" target="_blank">Create a Sandbox Store</a>
 
 Note that trial stores expire after 15 days and can't be populated with sample data.
 
@@ -45,7 +31,7 @@ Our BigCommerce integration supports the following plans: Standard, Plus, Pro, E
 
 ## Set up the integration
 
-After you've tested the integration, see [Set up the BigCommerce integration](/commerce-bigcommerce-setup) to learn how to enable your SMB customers to connect their commerce data using Link.
+After you've tested the integration, see [Set up the BigCommerce integration](/integrations/commerce/bigcommerce/commerce-bigcommerce-setup) to learn how to enable your SMB customers to connect their commerce data using Link.
 
 :::caution Platform rate limits
 

--- a/docs/integrations/commerce/chargebee/commerce-chargebee-setup.md
+++ b/docs/integrations/commerce/chargebee/commerce-chargebee-setup.md
@@ -5,7 +5,7 @@ createdAt: "2022-08-02T16:15:07.583Z"
 updatedAt: "2023-01-06T16:34:35.590Z"
 ---
 
-Set up the [Chargebee](/commerce-chargebee) integration to retrieve recurring billing and subscriptions data from your SMB customers.
+Set up the [Chargebee](/integrations/commerce/chargebee/commerce-chargebee) integration to retrieve recurring billing and subscriptions data from your SMB customers.
 
 Before you can use the integration, your SMB customers (merchants who use Chargebee) need to retrieve their secure API credentials from their Chargebee account and enter them in [Link](/auth-flow/overview). Chargebee does not require any global credentials for accessing the API.
 

--- a/docs/integrations/commerce/chargebee/commerce-chargebee-use.md
+++ b/docs/integrations/commerce/chargebee/commerce-chargebee-use.md
@@ -5,9 +5,9 @@ createdAt: "2022-08-02T15:56:09.330Z"
 updatedAt: "2022-10-19T16:28:15.495Z"
 ---
 
-The Chargebee integration is part of the [Domain discovery program](/domain-discovery-program), so Codat doesn't yet expose standardized data types or provide any data visualization or metrics (for example, in Assess).
+The Chargebee integration is part of the [Domain discovery program](/integrations/commerce/domain-discovery-program), so Codat doesn't yet expose standardized data types or provide any data visualization or metrics (for example, in Assess).
 
-Instead, when an SMB user has [linked their Chargebee account](/commerce-chargebee-setup#smb-customer-authenticate-and-connect-your-commerce-data), you can access their subscriptions and billing data through the `proxy` endpoint in the Codat API. Only GET requests are currently supported.
+Instead, when an SMB user has [linked their Chargebee account](/integrations/commerce/chargebee/commerce-chargebee-setup#smb-customer-authenticate-and-connect-your-commerce-data), you can access their subscriptions and billing data through the `proxy` endpoint in the Codat API. Only GET requests are currently supported.
 
 ## Send a proxy request
 
@@ -29,5 +29,5 @@ To view a list of all available endpoints, see the <a className="external" href=
 
 :::caution
 
-Use of the Chargebee integration is subject to participation in the Codat [Domain discovery program](/domain-discovery-program). Be aware of the program expectations before using the integration.
+Use of the Chargebee integration is subject to participation in the Codat [Domain discovery program](/integrations/commerce/domain-discovery-program). Be aware of the program expectations before using the integration.
 :::

--- a/docs/integrations/commerce/chargebee/commerce-chargebee.md
+++ b/docs/integrations/commerce/chargebee/commerce-chargebee.md
@@ -5,17 +5,14 @@ createdAt: "2022-08-01T14:36:49.455Z"
 updatedAt: "2022-10-20T13:33:08.523Z"
 ---
 
-<a className="external" href="https://www.chargebee.com/" target="_blank">
-  Chargebee
-</a> is a subscription billing management platform that enables merchants to streamline
-their recurring billing and subscription payment processes.
+<a className="external" href="https://www.chargebee.com/" target="_blank">Chargebee</a> is a subscription billing management platform that enables merchants to streamline their recurring billing and subscription payment processes.
 
 Use Codat's Commerce API with Chargebee to securely connect to, retrieve, and view your customers' recurring sales and subscription transactions.
 
 ## Data type coverage
 
-The Chargebee integration is part of the [Domain Discovery Program](/domain-discovery-program), so it doesn't yet expose any standardized commerce data types. Please contact your Account Manager or Account Executive to find out more and gain access.
+The Chargebee integration is part of the [Domain Discovery Program](/integrations/commerce/domain-discovery-program), so it doesn't yet expose any standardized commerce data types. Please contact your Account Manager or Account Executive to find out more and gain access.
 
 ## Set up the integration
 
-See [Set up the Chargebee integration](/commerce-chargebee-setup) to learn how to set up and enable the integration.
+See [Set up the Chargebee integration](/integrations/commerce/chargebee/commerce-chargebee-setup) to learn how to set up and enable the integration.

--- a/docs/integrations/commerce/chargify/commerce-chargify-setup.md
+++ b/docs/integrations/commerce/chargify/commerce-chargify-setup.md
@@ -5,7 +5,7 @@ createdAt: "2022-08-08T13:28:16.586Z"
 updatedAt: "2023-01-06T16:35:29.843Z"
 ---
 
-Set up the [Chargify](/commerce-chargify) integration to retrieve recurring billing and subscriptions data from your SMB customers.
+Set up the [Chargify](/integrations/commerce/chargify/commerce-chargify) integration to retrieve recurring billing and subscriptions data from your SMB customers.
 
 Before you can use the integration, your SMB customers (merchants who use Chargify) need to retrieve their secure API credentials from their Chargify account and enter them in [Link](/auth-flow/overview). Chargify does not require any global credentials for accessing the API.
 

--- a/docs/integrations/commerce/chargify/commerce-chargify-use.md
+++ b/docs/integrations/commerce/chargify/commerce-chargify-use.md
@@ -5,9 +5,9 @@ createdAt: "2022-08-08T15:57:27.458Z"
 updatedAt: "2022-10-19T16:29:45.213Z"
 ---
 
-The Chargify integration is part of the [Domain discovery program](/domain-discovery-program), so Codat doesn't yet expose standardized data types or provide any data visualization or metrics (for example, in Assess).
+The Chargify integration is part of the [Domain discovery program](/integrations/commerce/domain-discovery-program), so Codat doesn't yet expose standardized data types or provide any data visualization or metrics (for example, in Assess).
 
-Instead, when an SMB customer (a company) has [linked their Chargify account](/commerce-chargify-setup), you can access their subscriptions and billing data through the `proxy` endpoint in the Codat API. Only GET requests are currently supported.
+Instead, when an SMB customer (a company) has [linked their Chargify account](/integrations/commerce/chargify/commerce-chargify-setup), you can access their subscriptions and billing data through the `proxy` endpoint in the Codat API. Only GET requests are currently supported.
 
 ## Send a proxy request
 
@@ -23,5 +23,5 @@ To view a list of all available endpoints, see the <a className="external" href=
 
 :::caution
 
-Use of the Chargify integration is subject to participation in the Codat [Domain discovery program](/domain-discovery-program). Be aware of the program expectations before using the integration.
+Use of the Chargify integration is subject to participation in the Codat [Domain discovery program](/integrations/commerce/domain-discovery-program). Be aware of the program expectations before using the integration.
 :::

--- a/docs/integrations/commerce/chargify/commerce-chargify.md
+++ b/docs/integrations/commerce/chargify/commerce-chargify.md
@@ -5,17 +5,15 @@ createdAt: "2022-08-01T14:37:20.706Z"
 updatedAt: "2022-10-20T13:33:39.687Z"
 ---
 
-<a className="external" href="https://www.chargify.com/" target="_blank">
-  Chargify
-</a> is a subscription billing management platform that enables merchants to streamline
+<a className="external" href="https://www.chargify.com/" target="_blank">Chargify</a> is a subscription billing management platform that enables merchants to streamline
 their recurring billing and subscription payment processes.
 
 Use Codat's Commerce API with Chargify to securely connect to, retrieve, and view your customers' recurring sales and subscription transactions.
 
 ## Data type coverage
 
-The Chargify integration is part of the [Domain Discovery Program](/domain-discovery-program), so it doesn't yet expose any standardized commerce data types. Please contact your Account Manager or Account Executive to find out more and gain access.
+The Chargify integration is part of the [Domain Discovery Program](/integrations/commerce/domain-discovery-program), so it doesn't yet expose any standardized commerce data types. Please contact your Account Manager or Account Executive to find out more and gain access.
 
 ## Set up the integration
 
-See [Set up the Chargify integration](/commerce-chargify-setup) to learn how to set up and enable the integration.
+See [Set up the Chargify integration](/integrations/commerce/chargebee/commerce-chargebee-setup) to learn how to set up and enable the integration.


### PR DESCRIPTION
# Description

Fixes all internal links in the Amazon Seller Central, BigCommerce, Chargebee, and Chargify sections. 

## Type of change

Please delete options that are not relevant.

- [ ] New document(s)/updating existing
- [X] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)
