### PR TITLE
Sidebar fixes: Add on-prem connector setup and fix links from 2 API product pages

### DIFF
--- a/sidebars/banking-api.js
+++ b/sidebars/banking-api.js
@@ -9,16 +9,16 @@ module.exports = [
   {
     type: "link",
     label: "Banking data model",
-    href: "data-model/banking/",
+    href: "/data-model/banking/",
   },
   {
     type: "link",
     label: "Banking integrations",
-    href: "integrations/banking/overview",
+    href: "/integrations/banking/overview",
   },
   {
     type: "link",
-    href: "/banking-api",
     label: "Banking API reference",
+    href: "/banking-api",
   },
 ];

--- a/sidebars/commerce-api.js
+++ b/sidebars/commerce-api.js
@@ -9,16 +9,16 @@ module.exports = [
   {
     type: "link",
     label: "Commerce data model",
-    href: "data-model/commerce/",
+    href: "/data-model/commerce/",
   },
   {
     type: "link",
     label: "Commerce integrations",
-    href: "integrations/commerce/overview",
+    href: "/integrations/commerce/overview",
   },
   {
     type: "link",
-    href: "/commerce-api",
     label: "Commerce API reference",
+    href: "/commerce-api",
   },
 ];

--- a/sidebars/integrations.js
+++ b/sidebars/integrations.js
@@ -213,6 +213,7 @@ module.exports = [
           "integrations/accounting/zoho-books/zoho-books-integration-reference",
         ],
       },
+      "integrations/accounting/offline-connectors",
     ],
   },
   {


### PR DESCRIPTION
# Description

Fixes #74 

![image](https://user-images.githubusercontent.com/20324857/219376929-539255f4-36ff-43ba-9f55-ca263ab7e748.png)

Also fixes a couple of broken links from the Banking API and Commerce API homepages, which were missing the initial `/`s.

## Type of change

Please delete options that are not relevant.

- [x] Fixes
