### PR TITLE
Add holding notice to Shopify docs

### DIFF
--- a/docs/integrations/commerce/shopify/commerce-shopify-setup.md
+++ b/docs/integrations/commerce/shopify/commerce-shopify-setup.md
@@ -5,6 +5,12 @@ createdAt: "2021-01-14T16:41:39.945Z"
 updatedAt: "2023-01-06T16:44:14.501Z"
 ---
 
+:::caution Documentation under review
+
+Our documentation on using public apps to connect to Shopify is currently being reviewed. We'll publish updates to this content in the near future.
+
+:::
+
 Set up the Shopify integration to retrieve commerce data from customers who sell their products on Shopify's ecommerce platform.
 
 This article explains how to set up the Shopify integration using the _public apps_ connection method.

--- a/docs/integrations/commerce/shopify/commerce-shopify.md
+++ b/docs/integrations/commerce/shopify/commerce-shopify.md
@@ -20,6 +20,12 @@ Our Shopify integration allows your merchants to connect their commerce data usi
 - [Custom apps](/integrations/commerce/shopify/commerce-shopify-custom-apps)
 - [Public apps](/integrations/commerce/shopify/commerce-shopify-setup)
 
+   :::caution Documentation under review
+   
+   Our documentation on using public apps to connect to Shopify is currently being reviewed. We'll publish updates to this content in the near future.
+   
+   :::
+
 In general, custom apps require less initial setup, with tasks completed by the merchant. Public apps require more initial setup, with tasks completed by you, the Codat client.
 
 ## Custom apps overview and requirements

--- a/docs/integrations/commerce/shopify/commerce-shopify.md
+++ b/docs/integrations/commerce/shopify/commerce-shopify.md
@@ -20,11 +20,11 @@ Our Shopify integration allows your merchants to connect their commerce data usi
 - [Custom apps](/integrations/commerce/shopify/commerce-shopify-custom-apps)
 - [Public apps](/integrations/commerce/shopify/commerce-shopify-setup)
 
-   :::caution Documentation under review
+:::caution Documentation under review
    
-   Our documentation on using public apps to connect to Shopify is currently being reviewed. We'll publish updates to this content in the near future.
+Our documentation on using public apps to connect to Shopify is currently being reviewed. We'll publish updates to this content in the near future.
    
-   :::
+:::
 
 In general, custom apps require less initial setup, with tasks completed by the merchant. Public apps require more initial setup, with tasks completed by you, the Codat client.
 


### PR DESCRIPTION
# Description

Adds caution notes to the Shopify documentation.

## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)
