### PR TITLE
Add new change log entry for deprecating shared use of old accounting datatypes

### DIFF
--- a/blog/230710-deprecation-bankaccount-banktransaction.md
+++ b/blog/230710-deprecation-bankaccount-banktransaction.md
@@ -3,7 +3,7 @@ title: "Upcoming 2023-07-10: Deprecation of the use of bankAccounts and bankTran
 date: "2023-07-10"
 tags: ["Deprecation"]
 draft: true
-authors: d-laing
+authors: GraceCodat
 ---
 
 On July 10, 2023, Codat will deprecate the use of `bankAccounts` and `bankTransactions` data types for syncing banking data connections via Plaid, TrueLayer and Basiq. The use of these data types for accounting data connections will remain unchanged.

--- a/blog/230710-deprecation-bankaccount-banktransaction.md
+++ b/blog/230710-deprecation-bankaccount-banktransaction.md
@@ -13,7 +13,7 @@ Requests made to the following endpoints for banking data connections will no lo
 - `POST /companies/{companyId}/data/queue/{bankAccounts}`
 - `POST /companies/{companyId}/data/queue/{bankTransactions}`
 
-After the change is implemented a call to either of these endpoints for a Plaid, TrueLayer or Basiq data connection ID will return a 400 response. 
+After the change is implemented, a call to either of these endpoints for a Plaid, TrueLayer, or Basiq data connection ID will return a 400 response. 
 
 ## Action required​
 

--- a/blog/230710-deprecation-bankaccount-banktransaction.md
+++ b/blog/230710-deprecation-bankaccount-banktransaction.md
@@ -10,14 +10,14 @@ On July 10, 2023, Codat will deprecate the use of `bankAccounts` and `bankTransa
 
 Requests made to the following endpoints for banking data connections will no longer trigger a sync:
 
-- `POST /companies/{companyId}/data/queue/{bankAccounts}`
-- `POST /companies/{companyId}/data/queue/{bankTransactions}`
+- `POST /companies/{companyId}/data/queue/bankAccounts`
+- `POST /companies/{companyId}/data/queue/bankTransactions`
 
 After the change is implemented, a call to either of these endpoints for a Plaid, TrueLayer, or Basiq data connection ID will return a 400 response. 
 
 ## Action required​
 
-Switch to using the banking data types: [`banking-accounts`](https://docs.codat.io/banking-api#/schemas/Account) and [`banking-transactions`](https://docs.codat.io/banking-api#/schemas/Transaction). Enable these in your settings in the Portal.
+If you haven't already done so, switch to using the banking data types: [`banking-accounts`](https://docs.codat.io/banking-api#/schemas/Account) and [`banking-transactions`](https://docs.codat.io/banking-api#/schemas/Transaction). Enable these in your settings in the Portal.
 
 You will also need to update any parts of your code that expect the response body from the `banking-accounts` and `banking-transactions` endpoints. 
 For examples of the new response bodies for these data types, refer to the API reference.

--- a/blog/230710-deprecation-bankaccount-banktransaction.md
+++ b/blog/230710-deprecation-bankaccount-banktransaction.md
@@ -1,31 +1,30 @@
 ---
-title: "Upcoming 2023-07-10: Deprecation of the use of bankAccount and bankTransaction data types for banking data connections"
+title: "Upcoming 2023-07-10: Deprecation of the use of bankAccounts and bankTransactions data types for banking data connections"
 date: "2023-07-10"
 tags: ["Deprecation"]
 draft: true
 authors: d-laing
 ---
 
-On July 10, 2023, Codat will deprecate the use of bankAccount and bankTransaction data types for syncing banking data.
+On July 10, 2023, Codat will deprecate the use of `bankAccounts` and `bankTransactions` data types for syncing banking data connections via Plaid, TrueLayer and Basiq. The use of these data types for accounting data connections will remain unchanged.
 
 Requests made to the following endpoints for banking data connections will no longer trigger a sync:
 
-- `https://api.codat.io/swagger/index.html#/Data/post_companies__companyId__data_queue__dataType_`
-- `GET /companies/{companyId}/connections/{connectionId}/data/bankAccounts`
-- `GET /companies/{companyId}/connections/{connectionId}/data/bankTransactions`
+- `POST /companies/{companyId}/data/queue/{bankAccounts}`
+- `POST /companies/{companyId}/data/queue/{bankTransactions}`
 
-After the change is implemented, a call to either of these endpoints with bankAccount and bankTransaction data types for a data connection ID pertaining to a banking data connection will return a 400 response. 
+After the change is implemented a call to either of these endpoints for a Plaid, TrueLayer or Basiq data connection ID will return a 400 response. 
 
 ## Action required​
 
-Switch to using the banking data types: [Account](https://docs.codat.io/banking-api#/schemas/Account) and [Transaction](https://docs.codat.io/banking-api#/schemas/Transaction). Enable these in your settings in the Portal.
+Switch to using the banking data types: [`banking-accounts`](https://docs.codat.io/banking-api#/schemas/Account) and [`banking-transactions`](https://docs.codat.io/banking-api#/schemas/Transaction). Enable these in your settings in the Portal.
 
-You will also need to update any parts of your code that expect the response body from the Accounts and Transaction endpoints. 
+You will also need to update any parts of your code that expect the response body from the `banking-accounts` and `banking-transactions` endpoints. 
 For examples of the new response bodies for these data types, refer to the API reference.
 
 ## Expected impact if no action is taken​
 
-After July 10, 2023, calls made using the deprecated data types for banking data connections will return a 400 error:
+After July 10, 2023, calls made using `bankAccounts` and `bankTransactions` data types for a Plaid, TrueLayer or Basiq data connection ID will return a 400 error:
 
 ```json
 {

--- a/blog/230710-deprecation-bankaccount-banktransaction.md
+++ b/blog/230710-deprecation-bankaccount-banktransaction.md
@@ -1,0 +1,39 @@
+---
+title: "Upcoming 2023-07-10: Deprecation of the use of bankAccount and bankTransaction data types for banking data connections"
+date: "2023-07-10"
+tags: ["Deprecation"]
+draft: true
+authors: d-laing
+---
+
+On July 10, 2023, Codat will deprecate the use of bankAccount and bankTransaction data types for syncing banking data.
+
+Requests made to the following endpoints for banking data connections will no longer trigger a sync:
+
+- `https://api.codat.io/swagger/index.html#/Data/post_companies__companyId__data_queue__dataType_`
+- `GET /companies/{companyId}/connections/{connectionId}/data/bankAccounts`
+- `GET /companies/{companyId}/connections/{connectionId}/data/bankTransactions`
+
+After the change is implemented, a call to either of these endpoints with bankAccount and bankTransaction data types for a data connection ID pertaining to a banking data connection will return a 400 response. 
+
+## Action required​
+
+Switch to using the banking data types: [Account](https://docs.codat.io/banking-api#/schemas/Account) and [Transaction](https://docs.codat.io/banking-api#/schemas/Transaction). Enable these in your settings in the Portal.
+
+You will also need to update any parts of your code that expect the response body from the Accounts and Transaction endpoints. 
+For examples of the new response bodies for these data types, refer to the API reference.
+
+## Expected impact if no action is taken​
+
+After July 10, 2023, calls made using the deprecated data types for banking data connections will return a 400 error:
+
+```json
+{
+  "statusCode": 400,
+  "service": "PullApi",
+  "error": "Datatype 'bankAccounts' not supported by platform baecf6cb-402c-4611-ae02-b0b5f7e3384f",
+  "correlationId": "1f0ab3dcd57fe1de9c93b0a138fa56e5",
+  "canBeRetried": "Unknown",
+  "detailedErrorCode": 0
+}
+```


### PR DESCRIPTION
# Description

Deprecation of the shared use of bankAccount and bankTransaction datatypes for banking data connections.

## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)
