### PR TITLE
Sage Bank Feeds links

### DIFF
--- a/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds.md
+++ b/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds.md
@@ -27,7 +27,7 @@ You can push bank transactions to several [supported Sage products](/bank-feeds-
 
 ## Supported data types and operations
 
-Bank feeds are represented as streams of [Bank transactions](/accounting-api#/schemas/banktransactions) pushed to Codat in chronological order.
+Bank feeds are represented as streams of [Bank transactions](/accounting-api#/schemas/BankTransactions) pushed to Codat in chronological order.
 
 ## How it works
 
@@ -35,7 +35,7 @@ Bank feeds are represented as streams of [Bank transactions](/accounting-api#/sc
 2. Your end user can set up a bank feed using the _Connect Bank_ feature in a supported Sage product. They find your institution and then select a source bank account to send bank transactions from.
   
   They are redirected to a Codat UI to enter their data connection ID to authenticate with the integration - see the [SMB user flow](/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-setup#smb-user-flow-connect-a-source-bank-account-to-sage) for details. Alternatively, you can [authenticate users through your own web app](/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app).
-3. You push transactions for authenticated users to Codat using the [POST /bankTransactions](/codat-api#/operations/create-data-connection) endpoint - see [Use your Sage Bank Feeds integration](/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-use) for details.
+3. You push transactions for authenticated users to Codat using the [Create bank transactions](/accounting-api#/operations/post-bank-transactions) endpoint - see [Use your Sage Bank Feeds integration](/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-use) for details.
 
 ## Supported Sage products
 

--- a/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds.md
+++ b/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds.md
@@ -39,7 +39,7 @@ Bank feeds are represented as streams of [Bank transactions](/accounting-api#/sc
 
 ## Supported Sage products
 
-Our integration supports pushing bank feeds to several Sage products, including Sage Business Cloud, Sage Intacct, and Sage 50. For a complete list, see the <a className="external" href="https://developer.sage.com/banking-service/provider-api/what-is-sage-banking-service/supported-regions-products/" target="_blank">supported regions and products</a>.
+Our integration supports pushing bank feeds to several Sage products, including Sage Business Cloud, Sage Intacct, and Sage 50. For a complete list, see the [supported regions and products](https://developer.sage.com/banking-service/provider-api/banking-service/supported-regions-products/).
 
 ---
 


### PR DESCRIPTION
# Description

Fixes a broken link to the Banking Service docs and reformats the link to Markdown.

Also fixes two more links to the API reference.

## Type of change

- [x] Fixes

