### PR TITLE
Freeagent - Add call-outs for pushing Direct costs

### DIFF
--- a/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
+++ b/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
@@ -7,17 +7,31 @@ updatedAt: "2022-11-23T10:13:00.662Z"
 
 Note the following information when building your application using Codat's FreeAgent integration.
 
+## Direct costs
+
+Direct costs are mapped from [Bank Transaction Explanations](https://dev.freeagent.com/docs/bank_transaction_explanations) in FreeAgent. This object doesn't support multiple lines and therefore Direct costs pulled from FreeAgent only contain a single line in the `lineItems` array. You can also only push Direct costs that contain a single line, or an error is returned.
+
+When pulling Direct costs in foreign currencies, the `currencyRate` field is not populated due to limitations of the provider's API.
+
+When pushing Direct costs, the currency of the created object will be the same as that of the bank account. This is because FreeAgent doesn't allow users to post foreign currencies to a bank account.
+
+### Tax handling when pushing Direct costs
+
+You should be aware of the following behavior when pushing Direct costs with tax:
+
+- If `lineItems.taxAmount` is specified, and the account is taxable, the default tax rate for the account is ignored and overidden by this amount.
+- If `lineItems.taxAmount` is not specified, the default tax rate for the account in FreeAgent is applied (this is set on account creation)
+- To push a zero tax amount, set `lineItems.taxAmount` to `0`.
+
 ## Direct incomes
 
-Direct incomes are mapped from <a className="external" href="https://dev.freeagent.com/docs/bank_transaction_explanations" target="_blank">Bank Transaction Explanations</a> in FreeAgent. This object does not support multiple lines, so Direct incomes pulled from FreeAgent only include a single object in the `lineItems` array.
+Direct incomes are mapped from [Bank Transaction Explanations](https://dev.freeagent.com/docs/bank_transaction_explanations) in FreeAgent. This object does not support multiple lines, so Direct incomes pulled from FreeAgent only include a single object in the `lineItems` array.
 
 The `currencyRate` field is not populated when pulling Direct incomes in foreign currencies due to limitations of the provider's API.
 
-These notes also apply when pulling Direct costs from FreeAgent.
-
 ## Transfers
 
-Transfers are mapped from <a className="external" href="https://dev.freeagent.com/docs/bank_transactions" target="_blank">Bank transactions</a> in FreeAgent.
+Transfers are mapped from [Bank transactions](https://dev.freeagent.com/docs/bank_transactions) in FreeAgent.
 
 FreeAgent provides a unique transfer ID for each side of the transfer. Codat's data model requires a single unique ID to identify the transfer. In Codat, the transfer `id` identifies the _Transfer to Another Account_ side of the to/from Bank Transaction Explanation objects in FreeAgent. The transfer `id` is derived from the `url` property of the _Transfer to_ object.
 

--- a/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
+++ b/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
@@ -25,7 +25,7 @@ You should be aware of the following behavior when pushing Direct costs with tax
 
 ## Direct incomes
 
-Direct incomes are mapped from [Bank Transaction Explanations](https://dev.freeagent.com/docs/bank_transaction_explanations) in FreeAgent. This object does not support multiple lines, so Direct incomes pulled from FreeAgent only include a single object in the `lineItems` array.
+Direct incomes pulled from FreeAgent only contain a single line in the `lineItems` array.
 
 The `currencyRate` field is not populated when pulling Direct incomes in foreign currencies due to limitations of the provider's API.
 

--- a/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
+++ b/docs/integrations/accounting/freeagent/freeagent-integration-reference.md
@@ -13,7 +13,7 @@ Direct costs are mapped from [Bank Transaction Explanations](https://dev.freeage
 
 When pulling Direct costs in foreign currencies, the `currencyRate` field is not populated due to limitations of the provider's API.
 
-When pushing Direct costs, the currency of the created object will be the same as that of the bank account. This is because FreeAgent doesn't allow users to post foreign currencies to a bank account.
+When pushing Direct costs, the currency of the created object will be the same as that of the associated bank account. This is because FreeAgent doesn't allow users to post foreign currencies to bank accounts.
 
 ### Tax handling when pushing Direct costs
 


### PR DESCRIPTION
# Description

This pull request documents some caveats around pushing Direct costs to FreeAgent via our integration. It also aligns the existing text for Direct incomes to match.

Also removes some of the old link styling.

## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
