### PR TITLE
Updates to TrueLayer integration page

### DIFF
--- a/docs/integrations/banking/truelayer/banking-truelayer.md
+++ b/docs/integrations/banking/truelayer/banking-truelayer.md
@@ -23,5 +23,6 @@ Before you can set up the integration, you need to [register with TrueLayer](/in
 :::caution Data synced from TrueLayer might be limited
 
 If over 5 minutes has elapsed since a company was linked to TrueLayer, then the integration only fetches the **previous 90 days' worth of data**. Otherwise, the integration fetches all data.
+We strongly advise you enable [fetch on first link](/core-concepts/data-type-settings#use-fetch-on-first-link) when using TrueLayer to ensure all data requested is fetched within the 5 minute period.
 
 :::


### PR DESCRIPTION
Clients keep having issues with requesting historical data pre the 90 day window, and usually its because they don't have fetch on first link. Some wording here to advise clients on how to use the setting to ensure data fetched isn't limited.

- [X] New document(s)/updating existing

