### PR TITLE
Allow Datadog headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,10 @@
         {
           "key": "Access-Control-Allow-Methods",
           "value": "GET,OPTIONS"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "x-datadog-origin, x-datadog-parent-id, x-datadog-sampling-priority, x-datadog-trace-id"
         }
       ]
     }


### PR DESCRIPTION
# Description

Previous change didn't fix CORS issues. I think this is because it won't allow Datadog headers to be set, so we need to add these to the vercel config.

## Type of change

Please delete options that are not relevant.

- [ ] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [x] Bug fix (non-breaking change which fixes an issue)

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
