### PR TITLE
Add portal notice to deprecation announcement for new company synchronized rule

### DIFF
--- a/blog/231009-deprecation-webhooks-new-company-synchronized.md
+++ b/blog/231009-deprecation-webhooks-new-company-synchronized.md
@@ -24,3 +24,9 @@ If you have workflows that are dependent on the event of the first dataset compl
 ## Expected impact if no action is taken​
 
 This notification will be likely to arrive later than it currently does. If you have added code or workarounds that expect the webhook to be triggered when the first dataset is complete, you should remove or adjust these to align with the new behaviour. 
+
+:::note Get ahead
+
+You can get ahead of this change by enabling it now in the [Portal](https://app.codat.io/developers/api-deprecations). Learn how to do that [here](https://docs.codat.io/other/portal/developers), or read our [change policy](https://docs.codat.io/introduction/change-policy).
+
+:::


### PR DESCRIPTION
Add portal notice to deprecation announcement for new company synchronized rule

# Description

Add note informing clients that they can enable this deprecation in the portal, now that the feature switch appears in the portal.

## Type of change

- [ ] New document(s)/updating existing

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
