### PR TITLE
oracle-netsuite-faq-more-custom-form-detail

### DIFF
--- a/docs/integrations/accounting/netsuite/oracle-netsuite-faq.md
+++ b/docs/integrations/accounting/netsuite/oracle-netsuite-faq.md
@@ -38,7 +38,7 @@ NetSuite allows users to set custom forms for pages, including custom entry and 
 
 If the target page has a custom form set, data is pushed using the standard form for the page. Any custom fields which have been added to the custom form are not pushed.
 
-If the push operation fails, check the standard form for the page is active and is enabled for the required user role. Also check that the Codat bundle is updated to the latest version.
+If the push operation fails, check that the standard form for the page is active and is enabled for the required user role. If this is the case, next check that the standard form itself has not been modified. A common cause of push failure is custom fields on the standard form set as mandatory. 
 
 For more information, see <a className="external" href="https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_N2852749.html" target="_blank">Custom Forms</a> in the NetSuite documentation.
 


### PR DESCRIPTION

# Description

In the custom form section, added detail relating to the fact that the standard forms themselves can be modified. This is probably our most common cause of push failure and we need to make it clear that customised standard forms are incompatible with our system. 

Also removed the line about updating the bundle. Having the latest bundle is relevant for all troubleshooting of the NetSuite integration. Perhaps this could be called out elsewhere in the docs?


## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing


## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
