### PR TITLE
removed references to PUT /bankAccounts

### DIFF
--- a/docs/bank-feeds-api/qbo-bank-feeds/qbo-bank-feeds-setup.md
+++ b/docs/bank-feeds-api/qbo-bank-feeds/qbo-bank-feeds-setup.md
@@ -98,16 +98,15 @@ See the next procedure for details on the functionality to provide.
    }
    ```
 
-3. Using the [PUT /bankFeedAccounts](/bank-feeds-api#/operations/create-bank-feed) endpoint, add one or more source bank accounts. These are the accounts the SMB user will be able to connect to QBO.
+3. Using the [POST /bankFeedAccounts](/bank-feeds-api#/operations/create-bank-feed) endpoint, add one or more source bank accounts. These are the accounts the SMB user will be able to connect to QBO.
 
    ```http
-   PUT /companies/{companyId}/connections/{connectionId}/connectionInfo/bankFeedAccounts
+   POST /companies/{companyId}/connections/{connectionId}/connectionInfo/bankFeedAccounts
    ```
 
    In the request body, specify a list of bank accounts (all fields shown are required):
 
    ```json title="Example request body: add two checking accounts"
-   [
      {
        "id": "ac-001",
        "accountName": "account-001",
@@ -116,17 +115,7 @@ See the next procedure for details on the functionality to provide.
        "sortCode": "12-34-56",
        "currency": "USD",
        "balance": 4002 // can be 0
-     },
-     {
-       "id": "ac-002",
-       "accountName": "account-002",
-       "accountType": "checking",
-       "accountNumber": "89101112",
-       "sortCode": "12-34-56",
-       "currency": "USD",
-       "balance": 7300 // can be 0
      }
-   ]
    ```
 
    The endpoint returns a `200` response and the list of created bank accounts.

--- a/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-setup.md
+++ b/docs/bank-feeds-api/sage-bank-feeds/sage-bank-feeds-setup.md
@@ -107,17 +107,16 @@ To upload a logo, go to the <a className="external" href="https://app.codat.io/s
    Do _not_ send the `linkUrl` property to the SMB user. Unlike other Codat integrations, company authentication is initiated within Sage as described in "SMB user flow: Connect a source bank account to Sage", below.
    :::
 
-3. Using [PUT /bankFeedAccounts](/bank-feeds-api#/operations/create-bank-feed), add one or more source bank accounts to make available to the SMB user.
+3. Using [POST /bankFeedAccounts](/bank-feeds-api#/operations/create-bank-feed), add one or more source bank accounts to make available to the SMB user.
 
    ```http
-   PUT /companies/{companyId}/connections/{connectionId}/connectionInfo/bankFeedAccounts
+   POST /companies/{companyId}/connections/{connectionId}/connectionInfo/bankFeedAccounts
    ```
 
    In the request body, specify a list of bank accounts. For example, to add two credit card accounts, send the following request (all fields shown are required):
 
    ```json
-   [
-     {
+      {
        "id": "acc-002", // set to desired unique ID
        "accountName": "account-081",
        "sortCode": "123456",
@@ -125,17 +124,7 @@ To upload a logo, go to the <a className="external" href="https://app.codat.io/s
        "accountNumber": "12345670",
        "currency": "GBP",
        "balance": 99.99 // can be 0
-     },
-     {
-       "id": "acc-003", // set to desired unique ID
-       "accountName": "account-095",
-       "sortCode": "123456",
-       "accountType": "Credit",
-       "accountNumber": "12345671",
-       "currency": "GBP",
-       "balance": 100.09 // can be 0
      }
-   ]
    ```
 
 4. The endpoint returns a `200` code and the list of created bank accounts.


### PR DESCRIPTION
# Description
Small changes to remove references to PUT /bankAccounts and creating multiple accounts to make it consistent with deprecation notice.
- /bank-feeds-api/sage-bank-feeds/sage-bank-feeds-setup
- /bank-feeds-api/qbo-bank-feeds/qbo-bank-feeds-setup

## Type of change

- [x] Fixes



