### PR TITLE
Calling out limits on BigCommerce API

### DIFF
--- a/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-integration-reference.md
+++ b/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-integration-reference.md
@@ -12,7 +12,7 @@ The order status is not available in Orders pulled from BigCommerce. You can rev
 
 :::note Transaction limit on orders
 
-Orders containing more than 250 transactions (payments), are unable to to be fetched for our commerce-payments or commerce-orders datatypes correctly due to limitations of BigCommerce's API.
+Orders with more than 250 transactions (payments) cannot be fetched correctly for our `commerce-payments` or `commerce-orders` data types due to the limitations of BigCommerce's API.
 :::
 
 ## Payments methods

--- a/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-integration-reference.md
+++ b/docs/integrations/commerce/bigcommerce/commerce-bigcommerce-integration-reference.md
@@ -10,6 +10,11 @@ Note the following information when building your application using Codat's BigC
 
 The order status is not available in Orders pulled from BigCommerce. You can review the status of the associated payment using the `Payments.status` field.
 
+:::note Transaction limit on orders
+
+Orders containing more than 250 transactions (payments), are unable to to be fetched for our commerce-payments or commerce-orders datatypes correctly due to limitations of BigCommerce's API.
+:::
+
 ## Payments methods
 
 The `sourceModifiedDate` is not available for Payment Methods pulled from BigCommerce.


### PR DESCRIPTION
Order transactions paging doesn't work on bigcommerce so we have the max page size set but if this limit is breached by the data in bigcommerce we're not able to fetch it.

# Description

* Include a summary of the new content you're adding or the reason for the change. 
* Include relevant context.
* Do not link to work items.
* Any PNG images should be compressed using [Tiny PNG](https://tinypng.com/) or equivalent.

## Type of change

Please delete options that are not relevant.

- [X] New document(s)/updating existing

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
