### PR TITLE
remove metrics reference from menu

### DIFF
--- a/sidebars/assess.js
+++ b/sidebars/assess.js
@@ -90,16 +90,6 @@ module.exports = [
     items: [
       {
         type: "category",
-        label: "Accounting metrics",
-        collapsed: true,
-        items: [
-          "assess/metrics/accounting/overview",
-          "assess/metrics/accounting/api-financial-metrics",
-          "assess/metrics/accounting/api-marketing-metrics",
-        ],
-      },
-      {
-        type: "category",
         label: "Commerce metrics",
         collapsed: true,
         items: [


### PR DESCRIPTION
# Description

Accounting metrics have been deprecated. Removing these from the menu but keeping original pages as some clients have an extension on the deprecation

## Type of change

Please delete options that are not relevant.

- [ ] New document(s)/updating existing

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
