### PR TITLE
Rate limits - daily reset

### DIFF
--- a/docs/using-the-api/rate-limits.md
+++ b/docs/using-the-api/rate-limits.md
@@ -38,6 +38,13 @@ Client-based limits set an upper limit on the number of configuration changes in
 
 These transactions are intended to be low volume. Therefore, a high number of requests in this area indicates potentially erroneous behavior and should trigger contact with the client. 
 
+:::tip Client rate limit reset
+
+Client-based limits are calculated daily and reset at 00:00 UTC each day. You can use our dedicated [Client rate limit reset](/using-the-api/webhooks/core-rules-types#client-rate-limit-reset) webhook rule to be notified when the client-based limit resets.
+
+:::
+
+
 ### Company-based limits
 
 Company-based limits set an upper limit on the number of data-based requests an account can make against a company per day. This is to reduce the operational load. Codat sets these limits on the **ACC level** at: 
@@ -47,13 +54,21 @@ Company-based limits set an upper limit on the number of data-based requests an 
 
 Note that these limits represent a global request count.
 
+:::tip Company rate limit reset
+
+Company-based limits are calculated daily and reset at 00:00 UTC each day. 
+
+:::
+
 :::note Calculating rate limits: example 1
 
-Account A has a production client with 2 active companies. The client-based limit is calculated as the greater of `(2*100 || 1,000)`, resulting in 1,000 allowed requests. Adding 1,000 \* 2 ACCs for the company-based limit gives Account A a total limit of 3,000 requests. 
+Account A has a production client with 2 active companies. The client-based daily limit is calculated as the greater of `(2*100 || 1,000)`, resulting in 1,000 allowed requests. Adding 1,000 \* 2 ACCs for the company-based limit gives Account A a total limit of 3,000 requests. 
 
-They choose to make 1,100 requests against both companies for a total of 2,200 requests and have 800 requests remaining. 
+They choose to make 1,100 requests against both companies for a total of 2,200 requests and have 800 requests remaining for the day. 
 
-They then link a third company. Because the same total of requests applies, they can use the remaining 800 requests to make calls against the third company.
+They then link a third company. Because the same daily total of requests still applies, they can use the remaining 800 requests to make calls against the third company.
+
+When the rate limit resets the following day, the company limit will increase to 1,000 \* 3 = 3,000 to account for the newly linked company. This gives Account A a total limit of 4,000 requests.
 
 :::
 
@@ -81,3 +96,9 @@ Hard DoS-based limits are set to protect against bad actors and do not prevent s
 - 1,000 requests per minute from any IP Address.
 
 We may block an IP's traffic without warning if, in our view, it significantly interferes with the operation of our API.
+
+---
+
+## Read next
+
+- [Optimize calls to our API](/using-the-api/optimizing-api-calls)

--- a/docs/using-the-api/rate-limits.md
+++ b/docs/using-the-api/rate-limits.md
@@ -11,9 +11,7 @@ Handling rate limits is a challenging aspect of building financial integrations.
 
 ## Codat rate limits
 
-:::caution Rate limits enforced from 1<sup>st</sup> October 2023
-From October 1, 2023, rate limits listed on this page will be enforced by `api.codat.io`, and it will not be possible to make API calls that exceed the quota.
-:::
+Rate limits listed on this page are enforced by `api.codat.io`, and it is not possible to make API calls that exceed the quota.
 
 Codat will return a `429` status code for all requests to the API that are received while rate limiting is active. The body of the response will look like any other [error that gets returned by Codat](/using-the-api/errors).
 


### PR DESCRIPTION
# Description

/using-the-api/rate-limits
- Making daily reset of rate limits more visible
- Adding the same detail to the example 1 calculation
- Referencing the client rate limit webhook
- Adding a Read next section

## Type of change

- [X] New document(s)/updating existing