### PR TITLE
Update myob-integration-reference.md

### DIFF
--- a/docs/integrations/accounting/myob/myob-integration-reference.md
+++ b/docs/integrations/accounting/myob/myob-integration-reference.md
@@ -48,7 +48,9 @@ MYOB does not supply time information when the `issueDate` field is pulled by Co
 
 ### Performance
 
-MYOB recommend that company files in their system are kept below 2GB. If a company has a large amount of data, some timeouts will be expected when consuming their service. If Codat encounters a timeout error when fetching data from MYOB, we will retry the operation a number of times. This may lead to some datasets taking longer than expected to complete, but it can also lead to fetch errors. For further reading, please see [this article](https://apisupport.myob.com/hc/en-us/articles/6366818637583-504-Gateway-Time-out-errors) from their support knowledge base. 
+MYOB recommend that company files in their system are kept below 2GB. If a company has a large amount of data, some timeouts will be expected when consuming their service. If Codat encounters a timeout error when fetching data from MYOB, we will retry the operation a number of times. This may lead to some datasets taking longer than expected to complete or fetch errors. 
+
+To learn more, see the [504 Gateway Time out errors](https://apisupport.myob.com/hc/en-us/articles/6366818637583-504-Gateway-Time-out-errors) article in MYOB's support knowledge base. 
 
 ## FAQs
 

--- a/docs/integrations/accounting/myob/myob-integration-reference.md
+++ b/docs/integrations/accounting/myob/myob-integration-reference.md
@@ -46,6 +46,10 @@ MYOB AccountRight supports multiple currencies, but still operates with base cur
 
 MYOB does not supply time information when the `issueDate` field is pulled by Codat. As such, the date field value is always `yyyy-mm-ddT00:00:00`.
 
+### Performance
+
+MYOB recommend that company files in their system are kept below 2GB. If a company has a large amount of data, some timeouts will be expected when consuming their service. If Codat encounters a timeout error when fetching data from MYOB, we will retry the operation a number of times. This may lead to some datasets taking longer than expected to complete, but it can also lead to fetch errors. For further reading, please see [this article](https://apisupport.myob.com/hc/en-us/articles/6366818637583-504-Gateway-Time-out-errors) from their support knowledge base. 
+
 ## FAQs
 
 ### Where must company data be stored?


### PR DESCRIPTION
After an interaction/investigation with MYOB support, they've advised on the reliability/performance of their API in relation to companies with larger datasets. Have updated the 'integration behaviour' section in order to warn clients that long running fetches and even timeout failures are, (regrettably), to be expected when a company has a large amount of data in MYOB. 

## Type of change

- [ ] updating existing