### PR TITLE
Added library latest version to langauge cards in c#, typescript and python as well as prepped go and java

### DIFF
--- a/src/components/global/ClientLibraries/index.tsx
+++ b/src/components/global/ClientLibraries/index.tsx
@@ -8,32 +8,93 @@ const languages = [
         name: "typescript",
         namePretty: "TypeScript",
         icon: "/img/libraries/typescript.svg",
+        includeVersionInfo: true,
+        packageLocation: "https://www.npmjs.com/package/",
+        shield: "npm",
+        alt: "NPM version",
     },
     {
         name: "python",
         namePretty: "Python",
         icon: "/img/libraries/python.svg",
+        includeVersionInfo: true,
+        packageLocation: "https://pypi.python.org/pypi/",
+        shield: "pypi",
+        alt: "Python version",
     },
     {
         name: "csharp",
         namePretty: "C#",
         icon: "/img/libraries/csharp.svg",
+        includeVersionInfo: true,
+        packageLocation: "https://www.nuget.org/packages/",
+        shield: "nuget",
+        alt: "Nuget version",
     },
     {
         name: "go",
         namePretty: "Go",
+        includeVersionInfo: false,
         icon: "/img/libraries/go.svg",
+        packageLocation: "https://pkg.go.dev/github.com/codat/",
+        // shield: "https://pkg.go.dev/badge/github.com/svix",
+        alt: "Go version",
     },
     {
         name: "java",
         namePretty: "Java - Coming soon",
+        includeVersionInfo: false,
         icon: "/img/libraries/java.svg",
+        packageLocation: "https://search.maven.org/artifact/com.codat/",
+        alt: "Java version",
     },
 ]
 
+const capitalizeFirstCharacter = (name: string) => name.charAt(0).toUpperCase() + name.slice(1);
+
+const getCSharpPackageName = (productName) => {
+    let packageName = "Codat.";
+    if(productName.startsWith("sync-for")){
+        const name = productName.split("-").slice(-1)[0]
+        packageName += "Sync." + capitalizeFirstCharacter(name)
+    }
+    else{
+        packageName += productName.split("-").map(capitalizeFirstCharacter).join('')
+    }
+    return packageName;
+}
+
+const getPackageName = (productName, language) => {
+    // Product name is bank-feeds, lending, sync-for-expenses
+    switch(language){
+        case "typescript":
+            return "@codat/" + productName;
+        case "python":
+            return "codat-" + (productName !== "bank-feeds" ? productName : "bankfeeds");
+        case "csharp":
+            return getCSharpPackageName(productName)
+        case "go":
+            return "TBC"
+        case "java":
+            return "TBC"
+        default:
+            throw new Error('Unable to determine package name of ' + productName + 'in ' + language);
+    }
+}
+
+const getShieldUrl = (productName, language) => {
+    switch(language){
+        case "go":
+            throw new Error("No implemented for Go")
+        case "java":
+            return "https://img.shields.io/maven-central/v/com.codat/" + productName + "?label=maven-central%20(java)"
+        default:
+            return "https://img.shields.io/" + language.shield + "/v/" + getPackageName(productName, language.name)
+    }
+} 
+
 const ClientLibraries = ({productName}) => {
     const productUrl = !productName ? "" : "/tree/main/" + productName;
-    console.log("help: productName")
     return (
         <ul className="card-container mini">
             {
@@ -54,7 +115,14 @@ const ClientLibraries = ({productName}) => {
                                     <h4>{language.namePretty}</h4>
                                     <p>
                                     <a href={repoBaseUrl + language.name + productUrl} target="_blank">Start using →</a>
-                                    </p>    
+                                    </p>
+
+                                    {productName !== undefined && language.includeVersionInfo ?
+                                    <a href={language.packageLocation + getPackageName(productName, language.name)} target="_blank" >
+                                        <img loading="lazy" src={getShieldUrl(productName, language)} alt={language.alt}/>
+                                    </a>
+                                    : null
+                                    }
                                 </div>
                             </div>
                         </li>


### PR DESCRIPTION
Our language tiles now partially support displaying the latest version of the library for a given product. This works for c#, typescript and python. I need to work out how this is done for go and once Java is deployed finalise support for java. This change will help clients, support and implementations in understanding the latest versions of our packages.

# Description

* Include a summary of the new content you're adding or the reason for the change. 
* Include relevant context.
* Do not link to work items.
* Any PNG images should be compressed using [Tiny PNG](https://tinypng.com/) or equivalent.

## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
