### PR TITLE
Update synchronization-schedule.md

### DIFF
--- a/docs/commerce/synchronization-schedule.md
+++ b/docs/commerce/synchronization-schedule.md
@@ -9,7 +9,7 @@ image: "/img/banners/social/commerce.png"
 The schedule of regular data syncs depend on the following values:
 
 - Start date (selected by the merchant in the Sync Flow UI)
-- Sync hour (set by the Sync Flow to 00:00 am in the merchant's time zone)
+- Sync hour (set by the Sync Flow to the client default if available, otherwise it defaults to 00:00 am in the merchant's time zone)
 - Time zone (specified by the merchant in the Sync Flow UI)
 - Frequency (currently only daily)
 
@@ -21,7 +21,7 @@ The schedule of regular data syncs depend on the following values:
       "Monthly"
   ],
   "startDate": "2022-06-15",
-  "syncHourUtc": 0,
+  "syncHour": 0,
   "timeZone": "Europe/London"
 }
 
@@ -37,7 +37,7 @@ Despite the monthly option being present in the configuration file, currently we
 | Selected frequency (`selectedFrequency`) | _string_ | The sync frequency selected by the merchant. | Required |
 | Frequency options (`frequencyOptions`) | _string_ | The available options for sync frequency provided by Codat. **In the Sync Flow UI, only the daily option is available for a merchant to select.** | Required |
 | Start date (`startDate`) | _ISO 8601 datetime_ | The date from which commerce data syncing should start (only applies to the first sync). | Required |
-| Sync hour (`syncHourUtc`) | _Number_ <br/> Integers from 0 to 23 inclusive | The hour of the day that will mark the start/end of any sync period. **The Sync Flow sets this value automatically to midnight (00:00 am) in the merchant's time zone.** | Optional, set to 0 by default |
+| Sync hour (`syncHour`) | _Number_ <br/> Integers from 0 to 23 inclusive | The hour of the day that will mark the start/end of any sync period. **The Sync Flow sets this value automatically to the client default if available, otherwise it defaults to midnight (00:00am) in the merchant's time zone.** | Optional, set to the client default if available, otherwise to 0 |
 | Time zone (`timeZone`) | _string_ of IANA time zones **or** <br/> `null` (defaults to `Etc/UTC`) | The time zone applied to the start date and sync hour. | Optional, set to `ETC/Utc` by default |
 
 Once the [Sync Flow is completed and Codat receives the configuration](/commerce/build/implementing-codats-no-code-merchant-configuration), we use it to determine the **sync period** – the period for which commerce data will be synced in one run of the sync service.
@@ -46,7 +46,7 @@ To determine the sync period, we first establish the following values internally
 
 - The sync **due date**: the datetime a sync becomes due based on the sync hour. It will mark the end of one sync period and the beginning of the next.
 
-  Note that the Sync Flow sets the **sync hour** for you, and it's 00:00 am in the merchant's time zone. This means that the **due date** is at 00:00 am on the next day to the day we receive the configuration.
+  Note that the Sync Flow sets the **sync hour** for you, and it's the client default if available, otherwise it's 00:00 am in the merchant's time zone. This means that the **due date** is at the sync hour on the next day to the day we receive the configuration.
 
 - The sync **run date** which is the datetime of the next sync execution.
 


### PR DESCRIPTION
# Description

The syncHourUtc field has been replaced by a new syncHour field, and the logic surrounding the default syncHour value has also changed. These changes need to be reflected in the docs.

## Type of change

- [x] New document(s)/updating existing
