### PR TITLE
Replace build your own Xero management with connections SDK

### DIFF
--- a/docs/integrations/accounting/xero/partner-certification/checkpoints-lending.md
+++ b/docs/integrations/accounting/xero/partner-certification/checkpoints-lending.md
@@ -30,18 +30,9 @@ This checkpoint is not relevant to Lending Partnerships.
 
 ### 3. Connection
 
-**Action required: significant**
+**Action required: moderate**
 
-While Codat handles the initial connection to Xero via the Codat Link UI, Xero requires that you enable your user to manage this connection on an ongoing basis. Best practice is to create an "Integration settings" page to satisfy these requirements.
-
-| Requirement | Recommendations |
-| :-- | :-- |
-| Display the name of the tenant that has been connected | This can be retrieved from our [Get company info](/accounting-api#/operations/get-company-info) endpoint. |
-| Display the current status of the connection. If disconnected, provide a button to reconnect to Xero | Use our [Get connection](/platform-api#/operations/get-company-connection) endpoint to check the `status` of the connection and use the `linkUrl` to reconnect|
-| Provide a button to terminate the connection | When a user clicks on the button, use our [Unlink connection](/platform-api#/operations/unlink-connection) endpoint to disconnect from Xero. |
-| Handle a disconnect from Xero's side | Use a webhook to listen to our [DataConnectionStatusChanged](/using-the-api/webhooks/event-types) event that identifies when a disconnect happens. When the alert is triggered, change the connection status in your UI and display a "Reconnect" or "Connect" button. Xero recommends setting a regular daily sync of light data types so you can check each connected company's connection status every day.|
-| Support one-to-one or multi-organizational connection | Codat allows your customers to select their Xero organization using the native Xero UI. You can enable them to connect to multiple organizations within Xero by creating a separate Codat company per organization. |
-| Provide a disconnection process for off-boarding | Use our [Unlink connection](/platform-api#/operations/unlink-connection) endpoint to prevent further syncs or the [Delete connection](/platform-api#/operations/delete-company-connection) endpoint to prevent further syncs and querying of historically synced data.|
+While Codat handles the initial connection to Xero via the Codat Link UI, Xero also requires that you enable your user to manage this connection on an ongoing basis. The easiest way to do this is by implementing Codat's [Connections SDK](https://docs.codat.io/auth-flow/optimize/connection-management) into your front end. This follows best practice and complies with all of Xero's connection requirements.
 
 ### 4. Branding and naming
 

--- a/docs/integrations/accounting/xero/partner-certification/checkpoints-lending.md
+++ b/docs/integrations/accounting/xero/partner-certification/checkpoints-lending.md
@@ -32,7 +32,9 @@ This checkpoint is not relevant to Lending Partnerships.
 
 **Action required: moderate**
 
-While Codat handles the initial connection to Xero via the Codat Link UI, Xero also requires that you enable your user to manage this connection on an ongoing basis. The easiest way to do this is by implementing Codat's [Connections SDK](https://docs.codat.io/auth-flow/optimize/connection-management) into your front end. This follows best practice and complies with all of Xero's connection requirements.
+Xero requires that users can manage the connection between Codat and Xero on an ongoing basis. 
+
+The easiest way to do this is by implementing Codat's [Connections SDK](https://docs.codat.io/auth-flow/optimize/connection-management) into your front end. This follows best practice and complies with all of Xero's connection requirements.
 
 ### 4. Branding and naming
 


### PR DESCRIPTION
Removed steps to build your own "Integration settings" (connection management) page.
Replaced with link to new connections management SDK.

Happy to have this change revoked if further discussion needed.
