### PR TITLE
Removed items, added bankAccountRef

### DIFF
--- a/docs/expenses/sync-process/expense-transactions.md
+++ b/docs/expenses/sync-process/expense-transactions.md
@@ -48,46 +48,48 @@ To create a new expense transaction in Codat, use the [Create expense transactio
 In the request, make sure that the transaction's `id` is unique as it serves as an idempotence key. Codat validates the `id` to ensure that it's unique to a company, preventing the creation of duplicate transactions in your SMB's accounting software. 
 
 ```json title="Expense transaction request body"
-{
-  "items": [
-    {
-      "id": "08ca1f02-0374-11ed-b939-0242ac120002",
-      "type": "Payment",
-      "issueDate": "2023-12-13T00:00:00+00:00",
-      "currency": "GBP",
-      "currencyRate": 1.26,
-      "contactRef":{
-          "id":"an-id-to-a-suppliers-record",
-          "type": "Supplier"
-      },
-      "postAsDraft": false,
-      "merchantName": "Amazon UK",
-      "lines": [
-        {
-          "netAmount": 110.42,
-          "taxAmount": 14.43,
-          "taxRateRef": {
-            "id": "an-id-to-a-taxRates-record"
-          },
-          "accountRef": {
-            "id": "id-of-the-expense-nominal-account"
-          },
-          "trackingRefs": [
-            {
-              "id": "an-id-to-a-trackingCategories-record",
-              "dataType": "trackingCategories"
-            }
-          ],
-          "invoiceTo": {
-              "id": "an-id-to-a-customers-record",
-              "dataType": "customers"
+[
+  {
+    "id": "08ca1f02-0374-11ed-b939-0242ac120002",
+    "type": "Payment",
+    "issueDate": "2023-12-13T00:00:00+00:00",
+    "currency": "GBP",
+    "currencyRate": 1.26,
+    "contactRef":{
+        "id":"an-id-to-a-suppliers-record",
+        "type": "Supplier"
+    },
+    "bankAccountRef": {
+      "id": "an-id-to-a-bank-or-credit-card-account"
+    },
+    "postAsDraft": false,
+    "merchantName": "Amazon UK",
+    "lines": [
+      {
+        "netAmount": 110.42,
+        "taxAmount": 14.43,
+        "taxRateRef": {
+          "id": "an-id-to-a-taxRates-record"
+        },
+        "accountRef": {
+          "id": "id-of-the-expense-nominal-account"
+        },
+        "trackingRefs": [
+          {
+            "id": "an-id-to-a-trackingCategories-record",
+            "dataType": "trackingCategories"
           }
+        ],
+        "invoiceTo": {
+            "id": "an-id-to-a-customers-record",
+            "dataType": "customers"
         }
-      ],
-      "notes": "Amazon UK | Online Purchase | Order 123XX45"
-    }
-  ]
-}
+      }
+    ],
+    "notes": "Amazon UK | Online Purchase | Order 123XX45"
+  }
+]
+
 ```
 
 Next, you need to follow up with an expense sync to reflect this item of spend in the customer's accounting platform. We cover this in detail in [Sync expenses](/expenses/sync-process/syncing-expenses).

--- a/docs/expenses/sync-process/reimbursable-expense-transactions.md
+++ b/docs/expenses/sync-process/reimbursable-expense-transactions.md
@@ -49,48 +49,46 @@ To create a new reimbursable expense transaction in Codat, use the [Create reimb
 In the request URL, make sure that the transaction's `id` is unique as it serves as an idempotence key. Codat validates the `id` to ensure that it's unique to a company, preventing the creation of duplicate transactions in your SMB's accounting software. 
 
 ```json title="Reimbursable expense request body"
-{
-   "items":[
-      {
-         "id":"81539597-e681-40c9-a4dd-ec2fffcde572",
-         "reference":"101",
-         "contactRef":{
-            "id":"341"
-         },
-         "issueDate":"2022-04-29T00:00:00",
-         "dueDate":"2022-04-29T00:00:00",
-         "currency":"GBP",
-         "notes":"Reimbursable Expense Demo",
-         "lines":[
-            {
-               "netAmount":50,
-               "taxAmount":10,
-               "taxRateRef":{
-                  "id":"3_Bills"
+[
+   {
+      "id":"81539597-e681-40c9-a4dd-ec2fffcde572",
+      "reference":"101",
+      "contactRef":{
+         "id":"341"
+      },
+      "issueDate":"2022-04-29T00:00:00",
+      "dueDate":"2022-04-29T00:00:00",
+      "currency":"GBP",
+      "notes":"Reimbursable Expense Demo",
+      "lines":[
+         {
+            "netAmount":50,
+            "taxAmount":10,
+            "taxRateRef":{
+               "id":"3_Bills"
+            },
+            "accountRef":{
+               "id":"19"
+            },
+            "description":"Subscriptions",
+            "trackingRefs":[
+               {
+                  "id":"CLASS_5100000000000040021",
+                  "dataType":"trackingCategories"
                },
-               "accountRef":{
-                  "id":"19"
-               },
-               "description":"Subscriptions",
-               "trackingRefs":[
-                  {
-                     "id":"CLASS_5100000000000040021",
-                     "dataType":"trackingCategories"
-                  },
-                  {
-                     "id":"DEPARTMENT_5",
-                     "dataType":"trackingCategories"
-                  }
-               ]
-                "invoiceTo":{
-                  "id":"an-id-to-a-customers-record",
-                  "dataType":"customers"
+               {
+                  "id":"DEPARTMENT_5",
+                  "dataType":"trackingCategories"
                }
+            ]
+               "invoiceTo":{
+               "id":"an-id-to-a-customers-record",
+               "dataType":"customers"
             }
-         ]
-      }
-   ]
-}
+         }
+      ]
+   }
+]
 ```
 
 ### Billable reimbursable expenses


### PR DESCRIPTION
# Description

Push body for expense transactions using new create expense transaction was incorrect (included 'items' field) and also didn't include the bankAccountRef field. 

## Type of change

Please delete options that are not relevant.

- [ ] New document(s)/updating existing
- [x] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
