### PR TITLE
Update supplemental data overview

### DIFF
--- a/docs/using-the-api/supplemental-data/overview.md
+++ b/docs/using-the-api/supplemental-data/overview.md
@@ -112,4 +112,5 @@ Review the table below for platform schemas we use in our data types, which are 
 - If you configure properties that already exist in Codat's standard data model as supplemental properties, they will overwrite the standard data when creating records.
 
 
-- Deleted objects, indicated by `metadata.isDeleted flag` set to `true`, will not be enriched by supplemental data.  You can read more about [how we handle deleted data](https://docs.codat.io/updates/230411-deletion-of-data#additional-information). 
+- Deleted objects, indicated by `metadata.isDeleted flag` set to `true`, will not be enriched by supplemental data.  You can read more about [how we handle deleted data](https://docs.codat.io/updates/230411-deletion-of-data#additional-information).
+- Supplemental data is not supported for updating records. If you send changes to a pre-existing record's supplemental data object, these will be ignored by Codat. The PUT operation will appear to succeed, but there will be no change in the upstream system.


### PR DESCRIPTION
Making it more explicit that Supplemental Data is not currently supported when performing update operations

## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)

