### PR TITLE
Netsuite Journal Entry Currency Mapping Functionality Change

### DIFF
--- a/blog/240705-Netsuite-journal-entries-currency-deprecation copy.md
+++ b/blog/240705-Netsuite-journal-entries-currency-deprecation copy.md
@@ -1,0 +1,24 @@
+---
+title: "2024-07-05: Transaction Currency Mapping in Netsuite Integration"
+date: "2024-10-10"
+tags: ["Deprecation"]
+authors: codat-sean
+---
+
+We are updating our approach to handling transaction currencies in Netsuite journal entry mapping. Previously, transactions were mapped in the currency in which they were made, which could vary. From now on, we will use the base currency associated with the company for all transactions. This shift will enhance consistency and accuracy in our journal entry mappings across all integrations.
+
+## Action required
+
+- Review and update any custom integrations or workflows that rely on the old currency mapping behavior.
+
+-  Test the updated mapping to ensure accurate financial data representation in the base currency.
+
+## Expected impact if no action is taken
+
+- Inconsistent financial reporting.
+
+:::note Get ahead
+
+You can get ahead of this change by enabling it now in the [Portal](https://app.codat.io/developers/api-deprecations). Learn how to do that [here](https://docs.codat.io/configure/portal/developers), or read our [change policy](https://docs.codat.io/using-the-api/change-policy).
+
+:::

--- a/blog/240705-netsuite-journal-entries-currency-deprecation.md
+++ b/blog/240705-netsuite-journal-entries-currency-deprecation.md
@@ -11,7 +11,7 @@ We are updating our approach to handling transaction currencies in Netsuite jour
 
 - Review and update any custom integrations or workflows that rely on the old currency mapping behavior.
 
--  Test the updated mapping to ensure accurate financial data representation in the base currency.
+- Test the updated mapping to ensure accurate financial data representation in the base currency.
 
 ## Expected impact if no action is taken
 

--- a/blog/240705-netsuite-journal-entries-currency-deprecation.md
+++ b/blog/240705-netsuite-journal-entries-currency-deprecation.md
@@ -1,17 +1,15 @@
 ---
-title: "2024-07-05: Transaction Currency Mapping in Netsuite Integration"
+title: "2024-07-08: Journal Entry Currency Mapping in Netsuite Integration"
 date: "2024-10-10"
 tags: ["Deprecation"]
 authors: codat-sean
 ---
 
-We are updating our approach to handling transaction currencies in Netsuite journal entry mapping. Previously, transactions were mapped in the currency in which they were made, which could vary. From now on, we will use the base currency associated with the company for all transactions. This shift will enhance consistency and accuracy in our journal entry mappings across all integrations.
+We're refining our approach to currency handling in Netsuite journal entry mappings. Previously, entries were recorded in the currency of the transaction. Now, we'll standardize this by using the company's base currency for all entries, ensuring we are keeping consistent and accurate across all integrations.
 
 ## Action required
 
-- Review and update any custom integrations or workflows that rely on the old currency mapping behavior.
-
-- Test the updated mapping to ensure accurate financial data representation in the base currency.
+- Review and update any application logic or workflows that rely on the old currency mapping behavior.
 
 ## Expected impact if no action is taken
 


### PR DESCRIPTION
# Description

Mapping journal entries in Netsuite will now use the relevant companies base currency rather than the transactions currency. This is a change in behaviour, therfore a deprecation blog is required.

## Type of change
- [X] Fixes