### PR TITLE
Update role table for uploading data

### DIFF
--- a/docs/configure/user-management/user-roles.md
+++ b/docs/configure/user-management/user-roles.md
@@ -37,7 +37,7 @@ _Administrator_ users have full access to all the features available in the Coda
 | Add companies                             	| ✔          	| ✔       	| ✔         	| ✔             	|
 | View connection status                    	| ✔          	| ✔       	| ✔         	| ✔             	|
 | View company and integration data            	| ✔           	| ✔       	| ✔         	| ✔             	|
-| Upload company data                        	| ✔           	| ✔        	| ✔         	| ✔             	|
+| Upload files on behalf of a company                        	| ✔           	| ✔        	| ✔         	| ✔             	|
 | View and resolve webhooks and events         	|            	| ✔       	| ✔         	| ✔             	|
 | Delete companies                          	|            	|         	| ✔         	| ✔             	|
 | Add and update rules                      	|            	|         	| ✔         	| ✔             	|

--- a/docs/configure/user-management/user-roles.md
+++ b/docs/configure/user-management/user-roles.md
@@ -37,13 +37,13 @@ _Administrator_ users have full access to all the features available in the Coda
 | Add companies                             	| ✔          	| ✔       	| ✔         	| ✔             	|
 | View connection status                    	| ✔          	| ✔       	| ✔         	| ✔             	|
 | View company and integration data            	| ✔           	| ✔       	| ✔         	| ✔             	|
+| Upload company data                        	| ✔           	| ✔        	| ✔         	| ✔             	|
 | View and resolve webhooks and events         	|            	| ✔       	| ✔         	| ✔             	|
 | Delete companies                          	|            	|         	| ✔         	| ✔             	|
 | Add and update rules                      	|            	|         	| ✔         	| ✔             	|
 | Configure Link                            	|            	|         	| ✔         	| ✔             	|
 | Manage integrations                       	|            	|         	| ✔         	| ✔             	|
 | Update settings                           	|            	|         	| ✔         	| ✔             	|
-| Add new data from within the Codat Portal 	|            	|         	| ✔         	| ✔             	|
 | Manage upcoming deprecations              	|            	|         	| ✔         	| ✔             	|
 | Add and update users                      	|            	|         	|           	| ✔             	|
 


### PR DESCRIPTION
# Description

Updating the user tole table define that any user role can upload data to the company. 

Existing role definitions:
![image](https://github.com/user-attachments/assets/b4c0409b-d4a1-4915-8241-722ea1cb13a5)


New role definitions:
![image](https://github.com/user-attachments/assets/c9988b21-151d-45bb-bb53-280326479a9b)


