### PR TITLE
Differentiate between analyst and onboarding roles

### DIFF
--- a/docs/configure/user-management/user-roles.md
+++ b/docs/configure/user-management/user-roles.md
@@ -39,6 +39,7 @@ _Administrator_ users have full access to all the features available in the Coda
 | View company and integration data (Portal)    | ✔           	| ✔       	| ✔         	| ✔             	|
 | View company and integration data (API)       | ✔           	| ✔       	| ✔         	| ✔             	|
 | Upload files on behalf of a company          	| ✔           	| ✔        	| ✔         	| ✔             	|
+| View company financial data                   |             	| ✔       	| ✔         	| ✔             	|
 | View and resolve webhooks and events         	|            	| ✔       	| ✔         	| ✔             	|
 | Add and update rules                      	|            	|         	| ✔         	| ✔             	|
 | Configure Link                            	|            	|         	| ✔         	| ✔             	|


### PR DESCRIPTION
# Description

I gave someone onboarding role because I thought the only difference between the `analyst` and `onboarding` roles was the webhook stuff - because of the table. When you read the description it clarifies that `analyst` also has access to financial data.

Feel free to edit this PR, just trying to a conversation going about making the distinction clear.

![image](https://github.com/user-attachments/assets/b96c7008-507f-4dd8-ac2d-f8081f0facb1)
![image](https://github.com/user-attachments/assets/f100dabc-e544-48bf-b286-08e18c5c7b75)

## Type of change

- [x] New document(s)/updating existing