### PR TITLE
Update docs to clarify when bank feeds account is created

### DIFF
--- a/docs/lending/guides/loan-writeback/configure.md
+++ b/docs/lending/guides/loan-writeback/configure.md
@@ -670,7 +670,7 @@ String lendersBankAccountId = sourceAccountResponse.oneOf.sourceAccountV2.id;
 
 #### Map source account
 
-To complete the setup, create a representation of the source account in the accounting software. Use the [Create bank feed account mapping](/lending-api#/operations/create-bank-account-mapping) endpoint to achieve this, mapping the source account without assigning a target account. This will create a target account automatically.
+To complete the setup, create a representation of the source account in the accounting software. Use the [Create bank feed account mapping](/lending-api#/operations/create-bank-account-mapping) endpoint to achieve this, mapping the source account without assigning a target account. This will create a target account automatically on the next operation (e.g. when you call [List bank feed account mappings](https://docs.codat.io/lending-api#/operations/get-bank-account-mapping))
 
 <Tabs>
 

--- a/docs/lending/guides/loan-writeback/configure.md
+++ b/docs/lending/guides/loan-writeback/configure.md
@@ -670,7 +670,7 @@ String lendersBankAccountId = sourceAccountResponse.oneOf.sourceAccountV2.id;
 
 #### Map source account
 
-To complete the setup, create a representation of the source account in the accounting software. Use the [Create bank feed account mapping](/lending-api#/operations/create-bank-account-mapping) endpoint to achieve this, mapping the source account without assigning a target account. This will create a target account automatically on the next operation (e.g. when you call [List bank feed account mappings](https://docs.codat.io/lending-api#/operations/get-bank-account-mapping))
+To complete the setup, create a representation of the source account in the accounting software. Use the [Create bank feed account mapping](/lending-api#/operations/create-bank-account-mapping) endpoint to achieve this, mapping the source account without assigning a target account. When implementing for Xero, this will create a target account automatically on the next operation (e.g. when you call the [List bank feed account mappings](https://docs.codat.io/lending-api#/operations/get-bank-account-mapping) endpoint).
 
 <Tabs>
 


### PR DESCRIPTION
# Description

As explained by @rmarcall the account is created automatically but apparently not immediately.

> The approach is a generic approach related to our implementation for POSTing bank account mappings, in that we're not waiting anywhere in the background to update it, but deferring until the next "operation" (GET mapping/Push bank transactions). Given the webhook will only be sent when you invoke that next action my recommendation would be to hit the GET endpoint after you POST, to retrieve the TargetAccountId property and if there is an error due to a failure on the Xero side handle that then. Using this flow means you don't need to rely on the webhook either

⚠️ Feel free to edit what I've written, the PR is just to get the idea across. You might even want to add another step with a code example for getting the mapping to make it more obvious.

## Type of change

- [x] New document(s)/updating existing