### PR TITLE
Update 241124-bank-feeds-sdk.md

### DIFF
--- a/blog/241124-bank-feeds-sdk.md
+++ b/blog/241124-bank-feeds-sdk.md
@@ -39,8 +39,10 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 1. Call the [Create a company](/bank-feeds-api#/operations/create-company) endpoint to create a representation of your customer in Codat.
 2. Get an access token for this company by calling the [Get company access token](/bank-feeds-api#/operations/get-company-access-token) endpoint.
 3. Initialize the Bank Feeds SDK, passing the access token to the component. 
+  
   The SDK will direct your customer to select their accounting software and create a data connection for that software as a result.
 4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint. 
+  
   Once accounts have been created, the SDK will redirect your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
 5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped.
 

--- a/blog/241124-bank-feeds-sdk.md
+++ b/blog/241124-bank-feeds-sdk.md
@@ -40,10 +40,10 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 2. Get an access token for this company by calling the [Get company access token](/bank-feeds-api#/operations/get-company-access-token) endpoint.
 3. Initialize the Bank Feeds SDK, passing the access token to the component. 
   
-  The SDK will direct your customer to select their accounting software and create a data connection for that software as a result.
+    The SDK will direct your customer to select their accounting software and create a data connection for that software as a result.
 4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint. 
   
-  Once accounts have been created, the SDK will redirect your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
+    Once accounts have been created, the SDK will redirect your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
 5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped.
 
 If your user authorizes your access but doesn't complete the accounts setup, we'll bring them straight back to where they left off when they return to the flow. Once they're fully set up, you can use this component to allow them to reconfigure their accounts or set up additional accounts. 

--- a/blog/241124-bank-feeds-sdk.md
+++ b/blog/241124-bank-feeds-sdk.md
@@ -38,9 +38,11 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 
 1. Call the [Create a company](/bank-feeds-api#/operations/create-company) endpoint to create a representation of your customer in Codat.
 2. Get an access token for this company by calling the [Get company access token](/bank-feeds-api#/operations/get-company-access-token) endpoint.
-3. Initialize the Bank Feeds SDK, passing the access token to the component. The SDK will direct your customer to select their accounting software.
-4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint. Once accounts have been created the SDK will redirect your customer to authorise the connection and map these source accounts to the relevant accounts in their accounting platform.
-5. Use the SDK's onFinish callback function to manage the completion of the bank feeds setup flow once the accounts are mapped.
+3. Initialize the Bank Feeds SDK, passing the access token to the component. 
+  The SDK will direct your customer to select their accounting software and create a data connection for that software as a result.
+4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint. 
+  Once accounts have been created, the SDK will redirect your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
+5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped.
 
 If your user authorizes your access but doesn't complete the accounts setup, we'll bring them straight back to where they left off when they return to the flow. Once they're fully set up, you can use this component to allow them to reconfigure their accounts or set up additional accounts. 
 

--- a/blog/241124-bank-feeds-sdk.md
+++ b/blog/241124-bank-feeds-sdk.md
@@ -38,9 +38,9 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 
 1. Call the [Create a company](/bank-feeds-api#/operations/create-company) endpoint to create a representation of your customer in Codat.
 2. Get an access token for this company by calling the [Get company access token](/bank-feeds-api#/operations/get-company-access-token) endpoint.
-3. Initialize the Bank Feeds SDK, passing the access token to the component. The SDK will direct your customer to select their accounting software and authorize access to it.
-4. Use the SDK's `onConnection` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint once authorized. The SDK will redirect your customer to map these source accounts to the relevant accounts in their accounting platform.
-5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped. 
+3. Initialize the Bank Feeds SDK, passing the access token to the component. The SDK will direct your customer to select their accounting software.
+4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint. Once accounts have been created the SDK will redirect your customer to authorise the connection and map these source accounts to the relevant accounts in their accounting platform.
+5. Use the SDK's onFinish callback function to manage the completion of the bank feeds setup flow once the accounts are mapped.
 
 If your user authorizes your access but doesn't complete the accounts setup, we'll bring them straight back to where they left off when they return to the flow. Once they're fully set up, you can use this component to allow them to reconfigure their accounts or set up additional accounts. 
 

--- a/docs/bank-feeds/bank-feeds-sdk.md
+++ b/docs/bank-feeds/bank-feeds-sdk.md
@@ -31,8 +31,10 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 
 1. Call the [Create a company](/bank-feeds-api#/operations/create-company) endpoint to create a representation of your customer in Codat.
 2. Get an access token for this company by calling the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint.
-3. Initialize the Bank Feeds SDK, passing the access token to the component. The SDK will direct your customer to select their accounting software and authorize access to it.
-4. Use the SDK's `onConnection` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint once authorized. The SDK will redirect your customer to map these source accounts to the relevant accounts in their accounting platform.
+3. Initialize the Bank Feeds SDK, passing the access token to the component. 
+  The SDK then directs your customer to select their accounting software and creates a data connection for that software.
+4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint once authorized. 
+  Once done, the SDK directs your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
 5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped. 
 
 If your user authorizes your access but doesn't complete the accounts setup, we'll bring them straight back to where they left off when they return to the flow. Once they're fully set up, you can use this component to allow them to reconfigure their accounts or set up additional accounts. 

--- a/docs/bank-feeds/bank-feeds-sdk.md
+++ b/docs/bank-feeds/bank-feeds-sdk.md
@@ -33,10 +33,10 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 2. Get an access token for this company by calling the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint.
 3. Initialize the Bank Feeds SDK, passing the access token to the component. 
 
-  The SDK then directs your customer to select their accounting software and creates a data connection for that software.
+    The SDK then directs your customer to select their accounting software and creates a data connection for that software.
 4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint once authorized. 
 
-  Once done, the SDK directs your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
+    Once done, the SDK directs your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
 5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped. 
 
 If your user authorizes your access but doesn't complete the accounts setup, we'll bring them straight back to where they left off when they return to the flow. Once they're fully set up, you can use this component to allow them to reconfigure their accounts or set up additional accounts. 

--- a/docs/bank-feeds/bank-feeds-sdk.md
+++ b/docs/bank-feeds/bank-feeds-sdk.md
@@ -32,8 +32,10 @@ Once your user initiates the bank feeds setup process, engage our SDK to establi
 1. Call the [Create a company](/bank-feeds-api#/operations/create-company) endpoint to create a representation of your customer in Codat.
 2. Get an access token for this company by calling the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint.
 3. Initialize the Bank Feeds SDK, passing the access token to the component. 
+
   The SDK then directs your customer to select their accounting software and creates a data connection for that software.
 4. Use the SDK's `onConnectionStarted` callback function prop to call the [Create source accounts](/bank-feeds-api#/operations/create-batch-source-account) endpoint once authorized. 
+
   Once done, the SDK directs your customer to authorize the data connection and map these source accounts to the relevant accounts in their accounting software.
 5. Use the SDK's `onFinish` callback function to manage the completion of the bank feeds setup flow once the accounts are mapped. 
 


### PR DESCRIPTION
The flow steps were incorrect. We were indicating customers should utilize the onConnection callback rather than onConnectionStarted before creating source accounts. For the bank feeds auth flow to be initialized with the correct scopes, the source accounts need to be present on the data connection. 



## Type of change

- [x] updating existing
- [x] Fixes

