### PR TITLE
Remove twitter link

### DIFF
--- a/nav.config.js
+++ b/nav.config.js
@@ -70,12 +70,6 @@ module.exports = {
           rel: null,
         },
         {
-          href: "https://twitter.com/codatdata",
-          label: "Twitter",
-          target: "_blank",
-          rel: null,
-        },
-        {
           href: "https://www.codat.io/blog/",
           label: "Blog",
           target: "_blank",


### PR DESCRIPTION
# Description

Removing the menu link to twitter - at some point codat has seemingly given up our twitter account and it has now been registered by a security researcher. As a result it is uncontrolled and we should remove all references to it

**Existing**
![image](https://github.com/user-attachments/assets/19c98e93-c3fb-4a15-8dfc-adea593a8575)

**Update**
![image](https://github.com/user-attachments/assets/fc8f4cd5-173a-49ad-be69-cfeb1d8813f8)


## Type of change

Please delete options that are not relevant.

- [x] New document(s)/updating existing
- [ ] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
