### PR TITLE
For-195 Docs diagram failing to load

### DIFF
--- a/docs/expenses/sync-process/expense-transactions.md
+++ b/docs/expenses/sync-process/expense-transactions.md
@@ -32,7 +32,6 @@ sequenceDiagram
   Codat-)Accounting: Sync expense transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
-  Codat-->>You:
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment

--- a/docs/expenses/sync-process/expense-transactions.md
+++ b/docs/expenses/sync-process/expense-transactions.md
@@ -32,6 +32,7 @@ sequenceDiagram
   Codat-)Accounting: Sync expense transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
+  Codat-->>You: Transaction status
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment

--- a/docs/expenses/sync-process/reimbursable-expense-transactions.md
+++ b/docs/expenses/sync-process/reimbursable-expense-transactions.md
@@ -33,7 +33,6 @@ sequenceDiagram
   Codat-)Accounting: Sync reimbursable expense transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
-  Codat-->>You:
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment

--- a/docs/expenses/sync-process/reimbursable-expense-transactions.md
+++ b/docs/expenses/sync-process/reimbursable-expense-transactions.md
@@ -33,6 +33,7 @@ sequenceDiagram
   Codat-)Accounting: Sync reimbursable expense transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
+  Codat-->>You: Transaction status
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment

--- a/docs/expenses/sync-process/transfer-transactions.md
+++ b/docs/expenses/sync-process/transfer-transactions.md
@@ -25,7 +25,6 @@ sequenceDiagram
   Codat-)Accounting: Sync transfer transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
-  Codat-->>You:
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment

--- a/docs/expenses/sync-process/transfer-transactions.md
+++ b/docs/expenses/sync-process/transfer-transactions.md
@@ -25,6 +25,7 @@ sequenceDiagram
   Codat-)Accounting: Sync transfer transaction from queue
   Codat->>-You: Sync Complete webhook event
   You->>Codat: Check transactions
+  Codat-->>You: Transaction status
   par Each successful reconciliation
     You->>+Codat: Post attachment
     Codat->>Accounting: Upload attachment


### PR DESCRIPTION
# Description

Diagrams weren't loading in sync for expenses due to an arrow not having a label. Added label to arrow

## Type of change

Please delete options that are not relevant.

- [ ] New document(s)/updating existing
- [X] Fixes
- [ ] Styling
- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviews and merging

You are responsible for getting your PR merged. Address review comments promptly and **make sure to merge the PR when ready**.
Feel free to 'Enable automerge' - your PR will automatically merge when accepted and passing the build.
