### PR TITLE
Adding Dockerfile to the code_utils

### DIFF
--- a/code_utils/code_finder.py
+++ b/code_utils/code_finder.py
@@ -88,10 +88,64 @@ class CodeFinder:
             print(f"Error writing to output file: {e}")
             sys.exit(1)
             
+    def has_imports(self, code_content:str, language:str):
+        """
+        Check if code snippet has import statements at the top.
+        
+        Args:
+            code_content (str): The code content to check
+            language (str): Programming language (python, javascript, csharp)
+            
+        Returns:
+            bool: True if code has imports, False otherwise
+        """
+        lines = code_content.strip().split('\n')
+        
+        # Skip empty lines and comments at the top
+        non_empty_lines = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped and not self._is_comment_line(stripped, language):
+                non_empty_lines.append(stripped)
+        
+        if not non_empty_lines:
+            return False
+            
+        # Check first few non-empty, non-comment lines for imports
+        lines_to_check = non_empty_lines[:10]  # Check first 10 meaningful lines
+        
+        import_patterns = {
+            'python': [r'^import\s+', r'^from\s+.+\s+import\s+'],
+            'javascript': [r'^import\s+', r'^const\s+.+=\s+require\(', r'^require\('],
+            'csharp': [r'^using\s+']
+        }
+        
+        patterns = import_patterns.get(language, [])
+        for line in lines_to_check:
+            for pattern in patterns:
+                if re.match(pattern, line, re.IGNORECASE):
+                    return True
+        
+        return False
+    
+    def _is_comment_line(self, line:str, language:str):
+        """Check if a line is a comment based on language syntax."""
+        comment_patterns = {
+            'python': [r'^\s*#'],
+            'javascript': [r'^\s*//', r'^\s*/\*'],
+            'csharp': [r'^\s*//', r'^\s*/\*']
+        }
+        
+        patterns = comment_patterns.get(language, [])
+        for pattern in patterns:
+            if re.match(pattern, line):
+                return True
+        return False
+
     def extract_code(self):
         """
         Extract code snippets from matching files and save them to temp directory.
-        Creates subdirectories for each programming language.
+        Creates subdirectories for each programming language with complete/incomplete folders.
         """
         if not self.matching_files:
             print("No matching files found. Run find_files_with_code() first.")
@@ -105,16 +159,20 @@ class CodeFinder:
         }
         
         
-        # Create subdirectories for each target language
+        # Create subdirectories for each target language with complete/incomplete folders
         for lang in CodeFinder.target_languages:
             lang_dir = self.temp_dir / lang
-            lang_dir.mkdir(parents=True, exist_ok=True)
+            complete_dir = lang_dir / 'complete'
+            incomplete_dir = lang_dir / 'incomplete'
+            
+            complete_dir.mkdir(parents=True, exist_ok=True)
+            incomplete_dir.mkdir(parents=True, exist_ok=True)
         
         print(f"Created temp directory structure at: {self.temp_dir}")
         
         # Counters for summary
         total_snippets = 0
-        snippets_by_lang = {lang: 0 for lang in CodeFinder.target_languages}
+        snippets_by_lang = {lang: {'complete': 0, 'incomplete': 0} for lang in CodeFinder.target_languages}
         
         # Process each matching file
         for file_path in self.matching_files:
@@ -137,21 +195,25 @@ class CodeFinder:
                         code_content = code_content.strip()
                         
                         if code_content:  # Only save non-empty snippets
+                            # Check if snippet has imports
+                            has_imports = self.has_imports(code_content, language)
+                            subdirectory = 'complete' if has_imports else 'incomplete'
+                            
                             # Generate filename based on source file and snippet index
                             source_name = Path(file_path).stem
                             source_name = re.sub(r'[^\w\-_]', '_', source_name)  # Clean filename
                             
                             filename = f"{source_name}_snippet_{i+1}{lang_extensions[language]}"
-                            snippet_path = self.temp_dir / language / filename
+                            snippet_path = self.temp_dir / language / subdirectory / filename
                             
                             # Save the code snippet
                             with open(snippet_path, 'w', encoding='utf-8') as snippet_file:
                                 snippet_file.write(code_content)
                             
                             total_snippets += 1
-                            snippets_by_lang[language] += 1
+                            snippets_by_lang[language][subdirectory] += 1
                             
-                            print(f"Extracted {language} snippet: {Path(language) / filename}")
+                            print(f"Extracted {language} snippet ({subdirectory}): {Path(language) / subdirectory / filename}")
                             
             except Exception as e:
                 print(f"Error processing file {file_path}: {e}")
@@ -160,7 +222,11 @@ class CodeFinder:
         # Print summary
         print(f"\nExtraction Summary:")
         print(f"- Total code snippets extracted: {total_snippets}")
-        for lang, count in snippets_by_lang.items():
-            if count > 0:
-                print(f"- {lang.capitalize()} snippets: {count}")
+        for lang, counts in snippets_by_lang.items():
+            total_lang_snippets = counts['complete'] + counts['incomplete']
+            if total_lang_snippets > 0:
+                print(f"- {lang.capitalize()} snippets: {total_lang_snippets}")
+                print(f"  - Complete (with imports): {counts['complete']}")
+                print(f"  - Incomplete (no imports): {counts['incomplete']}")
         print(f"- Snippets saved to: {self.temp_dir}")
+        print(f"- Organization: Each language has 'complete' and 'incomplete' subdirectories")

--- a/code_utils/docker/.dockerignore
+++ b/code_utils/docker/.dockerignore
@@ -1,0 +1,64 @@
+# Exclude unnecessary files from Docker build context
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.Python
+**/env/
+**/venv/
+**/.venv/
+**/pip-log.txt
+**/pip-delete-this-directory.txt
+
+# Node modules and TypeScript compilation outputs
+**/node_modules/
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/.npm
+**/.yarn-integrity
+**/dist/
+**/build/
+
+# .NET build outputs
+**/bin/
+**/obj/
+**/*.user
+**/*.suo
+**/*.cache
+**/packages/
+
+# Version control
+**/.git/
+**/.gitignore
+**/.gitattributes
+
+# IDE and editor files
+**/.vscode/
+**/.idea/
+**/*.swp
+**/*.swo
+*~
+
+# OS generated files
+**/.DS_Store
+**/.DS_Store?
+**/._*
+**/.Spotlight-V100
+**/.Trashes
+**/ehthumbs.db
+**/Thumbs.db
+
+# Documentation and temp files
+**/temp/incomplete/
+**/*.md
+**/*.txt
+**/output.txt
+**/link-results.json
+
+# Only include the complete code snippets and dependency files
+!temp/*/complete/
+!docker/requirements.txt
+!docker/package.json
+!docker/tsconfig.json
+!docker/CodatSnippets.csproj

--- a/code_utils/docker/CodatSnippets.csproj
+++ b/code_utils/docker/CodatSnippets.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Codat.Platform" Version="*" />
+    <PackageReference Include="Codat.BankFeeds" Version="*" />
+    <PackageReference Include="Codat.Lending" Version="*" />
+    <PackageReference Include="Codat.Sync.Commerce" Version="*" />
+    <PackageReference Include="Codat.Sync.Expenses" Version="*" />
+    <PackageReference Include="Codat.Sync.Payables" Version="*" />
+    <PackageReference Include="Codat.Sync.Payroll" Version="*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/code_utils/docker/Dockerfile
+++ b/code_utils/docker/Dockerfile
@@ -1,0 +1,128 @@
+# Multi-stage build for code snippets with Python, TypeScript, and .NET Core
+FROM ubuntu:22.04
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# Update package list and install common dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    apt-transport-https \
+    software-properties-common \
+    gnupg \
+    lsb-release \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python 3.11 and pip
+RUN apt-get update && apt-get install -y \
+    python3.11 \
+    python3.11-dev \
+    python3-pip \
+    python3.11-venv \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 18.x and npm
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs
+
+# Install TypeScript globally
+RUN npm install -g typescript ts-node @types/node
+
+# Install .NET 8.0 SDK
+RUN wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+    && dpkg -i packages-microsoft-prod.deb \
+    && rm packages-microsoft-prod.deb \
+    && apt-get update \
+    && apt-get install -y dotnet-sdk-8.0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create workspace directory structure
+WORKDIR /workspace
+RUN mkdir -p /workspace/code-snippets/python \
+             /workspace/code-snippets/javascript \
+             /workspace/code-snippets/csharp
+
+# ========================================
+# Python Project Setup with Codat SDKs
+# ========================================
+WORKDIR /workspace/code-snippets/python
+
+# Copy Python dependencies and install packages
+COPY docker/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy Python code snippets
+COPY temp/python/complete/ ./snippets/
+
+# ========================================
+# TypeScript Project Setup with Codat SDKs
+# ========================================
+WORKDIR /workspace/code-snippets/javascript
+
+# Copy TypeScript project files and install dependencies
+COPY docker/package.json ./package.json
+COPY docker/tsconfig.json ./tsconfig.json
+RUN npm install
+
+# Create src directory and copy TypeScript code snippets
+RUN mkdir -p src snippets
+COPY temp/javascript/complete/ ./snippets/
+
+# ========================================
+# C# Project Setup with Codat SDKs
+# ========================================
+WORKDIR /workspace/code-snippets/csharp
+
+# Copy C# project file and restore packages
+COPY docker/CodatSnippets.csproj ./CodatSnippets.csproj
+RUN dotnet restore
+
+# Copy C# code snippets
+COPY temp/csharp/complete/ ./snippets/
+
+# ========================================
+# Final Setup and Verification
+# ========================================
+WORKDIR /workspace/code-snippets
+
+# Verify installations and show project structure
+RUN echo "=== Environment Information ===" && \
+    echo "Python version:" && python --version && \
+    echo "Node.js version:" && node --version && \
+    echo "npm version:" && npm --version && \
+    echo "TypeScript version:" && tsc --version && \
+    echo ".NET version:" && dotnet --version && \
+    echo "" && \
+    echo "=== Python Packages Verified ===" && \
+    python -c "import requests; print('✓ requests')" && \
+    python -c "import codat_platform; print('✓ codat-platform')" || echo "codat-platform installed but may need configuration" && \
+    python --version | xargs echo "✓ Python:" && \
+    pip list | grep -E "(codat|pyright|requests)" && \
+    echo "" && \
+    echo "=== TypeScript Codat Packages ===" && \
+    cd javascript && npm list --depth=0 | grep codat && \
+    echo "" && \
+    echo "=== C# Codat Packages ===" && \
+    cd ../csharp && dotnet list package | grep -i codat && \
+    echo "" && \
+    echo "=== Project Structure ===" && \
+    find . -maxdepth 3 -type d | head -20 && \
+    echo "" && \
+    echo "=== Code Snippets Count ===" && \
+    find . -name "*.py" | wc -l | xargs echo "Python snippets:" && \
+    find . -name "*.ts" | wc -l | xargs echo "TypeScript snippets:" && \
+    find . -name "*.cs" | wc -l | xargs echo "C# snippets:"
+
+# README creation removed per user request
+
+# Set working directory to code snippets root
+WORKDIR /workspace/code-snippets
+
+# Default command
+CMD ["/bin/bash"]

--- a/code_utils/docker/build.bat
+++ b/code_utils/docker/build.bat
@@ -1,0 +1,34 @@
+@echo off
+REM Build script for the Code Snippets Docker container (Windows)
+REM This script builds a Docker image with Python, TypeScript, and .NET Core
+REM and copies all complete code snippets from the temp directory
+
+echo Building Code Snippets Docker container...
+echo This container includes:
+echo   - Python 3.11
+echo   - Node.js 18.x with TypeScript
+echo   - .NET 8.0 SDK
+echo   - Complete code snippets organized by language
+echo.
+
+REM Build the Docker image from the code_utils directory
+cd ..
+docker build -f docker/Dockerfile -t code-snippets:latest .
+
+if %ERRORLEVEL% EQU 0 (
+    echo.
+    echo ✅ Docker image built successfully!
+    echo.
+    echo To run the container:
+    echo   docker run -it code-snippets:latest
+    echo.
+    echo To run with volume mount for development:
+    echo   docker run -it -v %cd%:/host code-snippets:latest
+    echo.
+    echo To inspect the code snippets:
+    echo   docker run -it code-snippets:latest find /workspace/code-snippets -name "*.py" -o -name "*.ts" -o -name "*.cs"
+) else (
+    echo.
+    echo ❌ Docker build failed!
+    exit /b 1
+)

--- a/code_utils/docker/build.sh
+++ b/code_utils/docker/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Build script for the Code Snippets Docker container
+# This script builds a Docker image with Python, TypeScript, and .NET Core
+# and copies all complete code snippets from the temp directory
+
+echo "Building Code Snippets Docker container..."
+echo "This container includes:"
+echo "  - Python 3.11"
+echo "  - Node.js 18.x with TypeScript"
+echo "  - .NET 8.0 SDK"
+echo "  - Complete code snippets organized by language"
+echo ""
+
+# Build the Docker image from the code_utils directory
+cd ..
+docker build -f docker/Dockerfile -t code-snippets:latest .
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "✅ Docker image built successfully!"
+    echo ""
+    echo "To run the container:"
+    echo "  docker run -it code-snippets:latest"
+    echo ""
+    echo "To run with volume mount for development:"
+    echo "  docker run -it -v \$(pwd):/host code-snippets:latest"
+    echo ""
+    echo "To inspect the code snippets:"
+    echo "  docker run -it code-snippets:latest find /workspace/code-snippets -name '*.py' -o -name '*.ts' -o -name '*.cs'"
+else
+    echo ""
+    echo "❌ Docker build failed!"
+    exit 1
+fi

--- a/code_utils/docker/package.json
+++ b/code_utils/docker/package.json
@@ -10,12 +10,18 @@
   },
   "dependencies": {
     "@codat/platform": "^*",
+    "@codat/accounting": "^*",
     "@codat/bank-feeds": "^*",
+    "@codat/banking": "^*",
+    "@codat/commerce": "^*",
     "@codat/lending": "^*",
+    "@codat/assess": "^*",
+    "@codat/files": "^*",
     "@codat/sync-for-commerce": "^*",
     "@codat/sync-for-expenses": "^*",
     "@codat/sync-for-payables": "^*",
     "@codat/sync-for-payroll": "^*",
+    "@codat/sdk-connections": "^*",
     "axios": "^1.0.0"
   },
   "devDependencies": {

--- a/code_utils/docker/package.json
+++ b/code_utils/docker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "codat-snippets",
+  "version": "1.0.0",
+  "description": "Codat SDK code snippets environment",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "ts-node",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@codat/platform": "^*",
+    "@codat/bank-feeds": "^*",
+    "@codat/lending": "^*",
+    "@codat/sync-for-commerce": "^*",
+    "@codat/sync-for-expenses": "^*",
+    "@codat/sync-for-payables": "^*",
+    "@codat/sync-for-payroll": "^*",
+    "axios": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "ts-node": "^10.0.0"
+  }
+}

--- a/code_utils/docker/requirements.txt
+++ b/code_utils/docker/requirements.txt
@@ -1,4 +1,17 @@
+# Core Codat Python SDKs
 codat-platform
+codat-bankfeeds
+codat-common
+codat-banking
+codat-commerce
+codat-assess
+codat-accounting
+codat-sync-for-expenses
+codat-sync-for-payroll
+codat-sync-for-payables
+codat-files
+
+# Development and utility packages
 pyright
 requests
 python-dateutil

--- a/code_utils/docker/requirements.txt
+++ b/code_utils/docker/requirements.txt
@@ -1,0 +1,6 @@
+codat-platform
+pyright
+requests
+python-dateutil
+httpx
+pydantic

--- a/code_utils/docker/tsconfig.json
+++ b/code_utils/docker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*", "snippets/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
- I have updated the logic of the extract_code_from_files script, so that it separates the extracted files into complete and incomplete, based on whether or not we can resonably expect the code within the file to run in a self-contained manner
<img width="384" height="271" alt="image" src="https://github.com/user-attachments/assets/bf01269d-2b92-4db2-9a70-0dc54a3598f1" />

- I have a docker file which builds a container with Python, .NET Core and TypeScript installed.
- The Dockerfile copies the _complete_ code files into a corresponding project directory in the Container. 
- The Dockerfile then uses the following files to install dependencies including the Codat client SDKs for each lang:
- - requirements.txt (for Python)
- - tsconfig.json (for Typescript)
- - CodeSnippets.csproj (For C#) 

**NEXT STEPS**

Now we can extract all complete code snippets from the docs and copy them to a container with all the dependencies required to run them, we should be able to create _smoke-tests_ for all of them, but running static analysis tools to check for code errors. 

