### PR TITLE
Adding Script To Check Code Snippets

### DIFF
--- a/code_utils/README.md
+++ b/code_utils/README.md
@@ -1,8 +1,10 @@
 # Codat Documentation Code Utils
 
 Utilities for extracting and managing code snippets from Codat documentation.
-Currently consists of a single script `extract_code_from_files.py` which will find every markdown file
+Currently consists of two scripts `extract_code_from_files.py` & `check_extracted_code.py.  The former will find every markdown file
 in the docs directory containing a code snippet. It will then extract those snippets into files under a `temp/` directory. 
+
+The latter will copy those files into a container with all nessecary dependancies and perform checks that the imports and code are correct and would build.
 
 
 ## Usage
@@ -12,6 +14,10 @@ in the docs directory containing a code snippet. It will then extract those snip
 # Run the code extractor
 
 uv run extract_code_from_files.py
+
+# Run compiler checks on extracted code
+
+uv run check_extracted_code.py
 
 ## Development
 
@@ -27,7 +33,10 @@ uv sync --extra dev
 
 ## Structure
 
-- `code_finder.py` - Main CodeFinder class
-- `extract_code_from_files.py` - Entrypoint script. 
-- `temp/` - Generated code snippets (gitignored)
-- `files_with_code.txt` - List of files containing code (gitignored)
+- `code_finder.py` - CodeFinder class
+- `extract_code_from_files.py` - Entrypoint script for code extraction. 
+- `temp/` - Generated code snippets (gitignored).
+- `files_with_code.txt` - List of files containing code (gitignored).
+- `code_checker.py` - CodeChecker class.
+- `check_extracted_code.py` - Entrypoint script for code checking.
+- `docker/` - docker utils which enable the code snippets to be built with their dependacies and checked.

--- a/code_utils/check_extracted_code.py
+++ b/code_utils/check_extracted_code.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""
+Simple test script to validate extracted code snippets using CodeChecker.
+"""
+
+from code_checker import CodeChecker
+
+
+   
+if __name__ == "__main__":
+    checker = CodeChecker()
+    print(checker.check_complete_snippets())

--- a/code_utils/code_checker.py
+++ b/code_utils/code_checker.py
@@ -1,0 +1,244 @@
+"""
+Code Checker for validating code snippets across Python, TypeScript, and C#.
+This module builds and runs a Docker container to validate complete code snippets.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+
+class CodeChecker:
+    """
+    A class for validating code snippets by building and running validation commands
+    in a Docker container across Python, TypeScript, and C# environments.
+    """
+
+    def __init__(self, base_dir: Optional[Path] = None):
+        """
+        Initialize the CodeChecker.
+        
+        Args:
+            base_dir: Base directory path. Defaults to the directory containing this file.
+        """
+        self.base_dir = base_dir or Path(__file__).parent
+        self.docker_dir = self.base_dir / "docker"
+        self.build_script = self.docker_dir / "build.bat"
+        self.container_name = "code-snippets:latest"
+        
+    def _run_command(self, command: List[str], cwd: Optional[Path] = None, capture_output: bool = True) -> Tuple[int, str, str]:
+        """
+        Run a command and return the exit code, stdout, and stderr.
+        
+        Args:
+            command: Command and arguments to run
+            cwd: Working directory for the command
+            capture_output: Whether to capture output or let it stream to console
+            
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        try:
+            if capture_output:
+                result = subprocess.run(
+                    command,
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                    timeout=300  # 5 minute timeout
+                )
+                return result.returncode, result.stdout, result.stderr
+            else:
+                # Stream output to console
+                result = subprocess.run(command, cwd=cwd, timeout=300)
+                return result.returncode, "", ""
+        except subprocess.TimeoutExpired:
+            return 124, "", "Command timed out after 300 seconds"
+        except Exception as e:
+            return 1, "", f"Failed to run command: {str(e)}"
+
+    def _build_docker_image(self) -> Tuple[bool, str]:
+        """
+        Build the Docker image using build.bat.
+        
+        Returns:
+            Tuple of (success, message)
+        """
+        print("🔨 Building Docker image...")
+        
+        if not self.build_script.exists():
+            return False, f"Build script not found: {self.build_script}"
+        
+        # Run build.bat from the docker directory
+        exit_code, stdout, stderr = self._run_command(
+            [str(self.build_script)], 
+            cwd=self.docker_dir,
+            capture_output=True
+        )
+        
+        if exit_code == 0:
+            print("✅ Docker image built successfully!")
+            return True, "Docker build completed successfully"
+        else:
+            error_msg = f"Docker build failed with exit code {exit_code}"
+            if stderr:
+                error_msg += f"\nSTDERR: {stderr}"
+            if stdout:
+                error_msg += f"\nSTDOUT: {stdout}"
+            return False, error_msg
+
+    def _validate_python_snippets(self) -> Tuple[bool, str]:
+        """
+        Run pyright validation on Python snippets inside the container.
+        
+        Returns:
+            Tuple of (success, output/error message)
+        """
+        print("🐍 Validating Python snippets with pyright...")
+        print("-" * 60)
+        
+        command = [
+            "docker", "run", "--rm", self.container_name,
+            "bash", "-c", "cd python/snippets && pyright ."
+        ]
+        
+        exit_code, _, _ = self._run_command(command, capture_output=False)
+        
+        print("-" * 60)
+        if exit_code == 0:
+            print("  ✅ Python validation passed!")
+            return True, "Validation passed"
+        else:
+            print(f"  ❌ Python validation failed (exit code {exit_code})")
+            return False, f"Validation failed with exit code {exit_code}"
+
+    def _validate_typescript_snippets(self) -> Tuple[bool, str]:
+        """
+        Run TypeScript compiler on JavaScript/TypeScript snippets inside the container.
+        
+        Returns:
+            Tuple of (success, output/error message)
+        """
+        print("📜 Validating TypeScript snippets with tsc...")
+        print("-" * 60)
+        
+        command = [
+            "docker", "run", "--rm", self.container_name,
+            "bash", "-c", "cd javascript && tsc --noEmit"
+        ]
+        
+        exit_code, _, _ = self._run_command(command, capture_output=False)
+        
+        print("-" * 60)
+        if exit_code == 0:
+            print("  ✅ TypeScript validation passed!")
+            return True, "Validation passed"
+        else:
+            print(f"  ❌ TypeScript validation failed (exit code {exit_code})")
+            return False, f"Validation failed with exit code {exit_code}"
+
+    def _validate_csharp_snippets(self) -> Tuple[bool, str]:
+        """
+        Run C# validation script inside the container.
+        
+        Returns:
+            Tuple of (success, output/error message)
+        """
+        print("🔷 Validating C# snippets...")
+        print("-" * 60)
+        
+        command = [
+            "docker", "run", "--rm", self.container_name,
+            "bash", "-c", "cd /workspace/code-snippets/csharp && ./validate-csharp-snippets.sh"
+        ]
+        
+        exit_code, _, _ = self._run_command(command, capture_output=False)
+        
+        print("-" * 60)
+        if exit_code == 0:
+            print("  ✅ C# validation passed!")
+            return True, "Validation passed"
+        else:
+            print(f"  ❌ C# validation failed (exit code {exit_code})")
+            return False, f"Validation failed with exit code {exit_code}"
+
+    def check_complete_snippets(self) -> Dict[str, Dict[str, any]]:
+        """
+        Build Docker image and validate all complete code snippets.
+        
+        Returns:
+            Dictionary with validation results for each language:
+            {
+                'build': {'success': bool, 'message': str},
+                'python': {'success': bool, 'output': str},
+                'typescript': {'success': bool, 'output': str},
+                'csharp': {'success': bool, 'output': str}
+            }
+        """
+        results = {
+            'build': {'success': False, 'message': ''},
+            'python': {'success': False, 'output': ''},
+            'typescript': {'success': False, 'output': ''},
+            'csharp': {'success': False, 'output': ''}
+        }
+        
+        print("🚀 Starting code snippet validation...")
+        print("=" * 60)
+        
+        # Step 1: Build Docker image
+        build_success, build_message = self._build_docker_image()
+        results['build']['success'] = build_success
+        results['build']['message'] = build_message
+        
+        if not build_success:
+            print(f"❌ Docker build failed: {build_message}")
+            return results
+        
+        print("=" * 60)
+        
+        # Step 2: Validate Python snippets
+        python_success, python_output = self._validate_python_snippets()
+        results['python']['success'] = python_success
+        results['python']['output'] = python_output
+        
+        # Step 3: Validate TypeScript snippets
+        typescript_success, typescript_output = self._validate_typescript_snippets()
+        results['typescript']['success'] = typescript_success
+        results['typescript']['output'] = typescript_output
+        
+        # Step 4: Validate C# snippets
+        csharp_success, csharp_output = self._validate_csharp_snippets()
+        results['csharp']['success'] = csharp_success
+        results['csharp']['output'] = csharp_output
+        
+        # Summary
+        print("=" * 60)
+        print("📊 Validation Summary:")
+        
+        total_passed = sum([
+            python_success, 
+            typescript_success, 
+            csharp_success
+        ])
+        
+        if total_passed == 3:
+            print("🎉 All validations passed!")
+        else:
+            print(f"⚠️  {total_passed}/3 validations passed")
+            
+            # Show which validations failed (details already shown above)
+            failed_validations = []
+            if not python_success:
+                failed_validations.append("Python")
+            if not typescript_success:
+                failed_validations.append("TypeScript")
+            if not csharp_success:
+                failed_validations.append("C#")
+            
+            print(f"❌ Failed: {', '.join(failed_validations)}")
+        
+        return results
+
+

--- a/code_utils/docker/Dockerfile
+++ b/code_utils/docker/Dockerfile
@@ -86,6 +86,10 @@ RUN dotnet restore
 # Copy C# code snippets
 COPY temp/csharp/complete/ ./snippets/
 
+# Copy C# validation script
+COPY docker/validate-csharp-snippets.sh ./validate-csharp-snippets.sh
+RUN chmod +x validate-csharp-snippets.sh
+
 # ========================================
 # Final Setup and Verification
 # ========================================

--- a/code_utils/docker/tsconfig.json
+++ b/code_utils/docker/tsconfig.json
@@ -4,14 +4,11 @@
     "module": "commonjs",
     "lib": ["ES2020"],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "noEmit": true
   },
   "include": ["src/**/*", "snippets/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/code_utils/docker/validate-csharp-snippets.sh
+++ b/code_utils/docker/validate-csharp-snippets.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+SNIPPETS_PATH=${1:-"/workspace/code-snippets/csharp/snippets"}
+TEMP_DIR="/tmp/csharp-validation"
+TOTAL_ERRORS=0
+VALIDATED_COUNT=0
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🔍 Validating C# snippets individually...${NC}"
+
+# Template for individual snippet project
+create_project_file() {
+    local project_file="$1"
+    cat > "$project_file" << 'EOF'
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Codat.Platform" Version="*" />
+    <PackageReference Include="Codat.BankFeeds" Version="*" />
+    <PackageReference Include="Codat.Lending" Version="*" />
+    <PackageReference Include="Codat.Sync.Commerce" Version="*" />
+    <PackageReference Include="Codat.Sync.Expenses" Version="*" />
+    <PackageReference Include="Codat.Sync.Payables" Version="*" />
+    <PackageReference Include="Codat.Sync.Payroll" Version="*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>
+EOF
+}
+
+# Clean up any existing temp directory
+if [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+fi
+
+# Find all .cs files
+if [ ! -d "$SNIPPETS_PATH" ]; then
+    echo -e "${YELLOW}⚠️  Snippets directory not found: $SNIPPETS_PATH${NC}"
+    exit 0
+fi
+
+# Count .cs files
+CS_FILES_COUNT=$(find "$SNIPPETS_PATH" -name "*.cs" -type f | wc -l)
+
+if [ "$CS_FILES_COUNT" -eq 0 ]; then
+    echo -e "${YELLOW}⚠️  No C# files found in $SNIPPETS_PATH${NC}"
+    exit 0
+fi
+
+echo -e "${GREEN}📁 Found $CS_FILES_COUNT C# snippet files${NC}"
+
+# Process each .cs file
+find "$SNIPPETS_PATH" -name "*.cs" -type f | sort | while read -r file; do
+    VALIDATED_COUNT=$((VALIDATED_COUNT + 1))
+    SNIPPET_NAME=$(basename "$file" .cs)
+    PROJECT_DIR="$TEMP_DIR/$SNIPPET_NAME"
+    
+    echo -e "${CYAN}🔄 [$VALIDATED_COUNT/$CS_FILES_COUNT] Validating: $SNIPPET_NAME${NC}"
+    
+    # Create project directory
+    mkdir -p "$PROJECT_DIR"
+    
+    # Create project file
+    PROJECT_FILE="$PROJECT_DIR/$SNIPPET_NAME.csproj"
+    create_project_file "$PROJECT_FILE"
+    
+    # Copy snippet as Program.cs
+    PROGRAM_FILE="$PROJECT_DIR/Program.cs"
+    cp "$file" "$PROGRAM_FILE"
+    
+    # Restore packages for this project
+    RESTORE_OUTPUT=$(dotnet restore "$PROJECT_FILE" -v q 2>&1)
+    RESTORE_EXIT_CODE=$?
+    
+    if [ $RESTORE_EXIT_CODE -ne 0 ]; then
+        echo -e "  ${RED}❌ $SNIPPET_NAME - RESTORE FAILED${NC}"
+        echo -e "  ${RED}   Restore output:${NC}"
+        echo "$RESTORE_OUTPUT" | sed 's/^/     /' | while read -r line; do
+            echo -e "  ${RED}$line${NC}"
+        done
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        echo "$TOTAL_ERRORS" > "$TEMP_DIR/error_count"
+        continue
+    fi
+    
+    # Build the project (capture both stdout and stderr)
+    BUILD_OUTPUT=$(dotnet build "$PROJECT_FILE" --no-restore -v q 2>&1)
+    BUILD_EXIT_CODE=$?
+    
+    if [ $BUILD_EXIT_CODE -eq 0 ]; then
+        echo -e "  ${GREEN}✅ $SNIPPET_NAME - OK${NC}"
+    else
+        echo -e "  ${RED}❌ $SNIPPET_NAME - BUILD FAILED${NC}"
+        echo -e "  ${RED}   Build output:${NC}"
+        echo "$BUILD_OUTPUT" | sed 's/^/     /' | while read -r line; do
+            echo -e "  ${RED}$line${NC}"
+        done
+        TOTAL_ERRORS=$((TOTAL_ERRORS + 1))
+        # Write error count to temp file since subshell can't modify parent variables
+        echo "$TOTAL_ERRORS" > "$TEMP_DIR/error_count"
+    fi
+done
+
+# Read final error count
+if [ -f "$TEMP_DIR/error_count" ]; then
+    TOTAL_ERRORS=$(cat "$TEMP_DIR/error_count")
+else
+    TOTAL_ERRORS=0
+fi
+
+# Clean up temp directory
+if [ -d "$TEMP_DIR" ]; then
+    rm -rf "$TEMP_DIR"
+fi
+
+echo ""
+if [ "$TOTAL_ERRORS" -eq 0 ]; then
+    echo -e "${GREEN}🎉 All $CS_FILES_COUNT C# snippets validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}❌ Validation completed with $TOTAL_ERRORS errors out of $CS_FILES_COUNT snippets${NC}"
+    exit 1
+fi


### PR DESCRIPTION
This is the first iteration of a Python utility which actually checks the correctness of the doc's code snippets. 

The code_utils folder now contains two scripts:

- One to pull out all code snippets and divide them into _complete_ and _incomplete_
- One to build a container containing all necessary dependencies and attempt to compile* ** the complete scripts

* compile for Python means use `pyright` (which powers VS Code's Python Language server... a.k.a puts the squiggly red lines in the IDE editor when the code is wrong). 

** .NET's project based nature doesn't lend itself well to self contained scripts, or at least not compiling a lot of self contained scripts as part of a single project. [validate-csharp-snippets.sh](https://github.com/codatio/codat-docs/compare/main...adding-actual-checks?expand=1#diff-4776d64dc1814cafe35bea4c17b73ff203c48d07ae716fa3f47613be81e2bcc7) is a shell script which shuffles the self contained csharp snippets into their own projects, and attempts to compile them, to avoid namespace errors. 


**FUTURE DEVELOPMENT**

- make the scripts and their component parts a CLI tool for composability and ease of use. 
- look to make the container a bit slimmer by using different base image and the layers more efficiently (its currently well over 2 GB) 
- a bit of a mishmash of scripts and languages, etc... rather than have a python script invoke a .bat file to build the container, control everything from the Python CLI tool. 

