### PR TITLE
Add blog post: encourage connecting more banking accounts in Link

### DIFF
--- a/blog/260415-link-banking-encourage-connections.md
+++ b/blog/260415-link-banking-encourage-connections.md
@@ -1,7 +1,7 @@
 ---
 title: "Link: encourage connecting more banking accounts"
-date: "2026-04-24"
-tags: ["Product", "Update"]
+date: "2026-04-15"
+tags: ["Product", "Update", "Link"]
 hide_table_of_contents: false
 authors: pmckinney
 ---

--- a/blog/260415-link-banking-encourage-connections.md
+++ b/blog/260415-link-banking-encourage-connections.md
@@ -1,0 +1,35 @@
+---
+title: "Link: encourage connecting more banking accounts"
+date: "2026-04-24"
+tags: ["Product", "Update"]
+hide_table_of_contents: false
+authors: pmckinney
+---
+
+On **24 April 2026**, we will update the Link flow to encourage users to connect more than one banking account, giving lenders a fuller picture of their customers' cash flow.
+
+<!--truncate-->
+
+## What's new?
+
+After a user successfully connects a banking account in Link, they are prompted to connect another. This happens in two places:
+
+**On connection success**, users see a "We recommend adding more bank accounts" prompt with a primary **Connect another account** button and a secondary **Continue** option. There is also a tooltip providing users with information on why they should connect another account.
+
+![Plaid connected — prompt to connect another account](/img/updates/260415-link-banking-plaid-connected.png)
+
+**On the main Link screen**, the Banking step shows an **Add another** button tagged **Recommended**, alongside information on why this would provide extra value.
+
+![Link screen — Add another banking account](/img/updates/260415-link-banking-add-another.png)
+
+Previously, users would complete the flow after connecting a single account, with no clear suggestion to add more. Merchants who connect multiple accounts give their lenders a fuller picture of their cash flow, leading to better lending decisions and improved conversion rates. This addresses a commonly reported pattern where merchants connect only one account.
+
+The prompt applies to banking integrations connected via both **Plaid** and **TrueLayer**.
+
+## Who is this relevant for?
+
+All clients using Link — either the [Hosted Link flow](/auth-flow/overview) or the [Link SDK](/auth-flow/authorize-embedded-link) — with banking integrations enabled.
+
+## How to get started?
+
+No action is required. The updated flow will be available to all customers using Link with banking integrations from **24 April 2026**.

--- a/blog/260415-link-banking-encourage-connections.md
+++ b/blog/260415-link-banking-encourage-connections.md
@@ -1,35 +1,37 @@
 ---
-title: "Link: encourage connecting more banking accounts"
-date: "2026-04-15"
+title: "Link: drive more bank account connections"
+date: "2026-04-17"
 tags: ["Product", "Update", "Link"]
 hide_table_of_contents: false
 authors: pmckinney
 ---
 
-On **24 April 2026**, we will update the Link flow to encourage users to connect more than one banking account, giving lenders a fuller picture of their customers' cash flow.
+On **April 24, 2026**, we will update the Link flow to encourage users to connect more than one bank account.
 
 <!--truncate-->
 
 ## What's new?
 
-After a user successfully connects a banking account in Link, they are prompted to connect another. This happens in two places:
+When a user successfully connects a bank account in Link, they are now prompted to connect another. The prompt appears in two places:
 
-**On connection success**, users see a "We recommend adding more bank accounts" prompt with a primary **Connect another account** button and a secondary **Continue** option. There is also a tooltip providing users with information on why they should connect another account.
+1. **On the connection success screen**, users see a _We recommend adding more bank accounts_ message with a primary **Connect another account** button.
 
-![Plaid connected — prompt to connect another account](/img/updates/260415-link-banking-plaid-connected.png)
+    A secondary **Continue** button on the screen skips additional account creation. A tooltip explains why connecting additional accounts is beneficial.
 
-**On the main Link screen**, the Banking step shows an **Add another** button tagged **Recommended**, alongside information on why this would provide extra value.
+    ![Plaid connected — prompt to connect another account](/img/updates/260415-link-banking-plaid-connected.png)
 
-![Link screen — Add another banking account](/img/updates/260415-link-banking-add-another.png)
+2. **On the main Link screen**, the Banking step displays an **Add another** button tagged _Recommended_ and provides context on the value of connecting more accounts.
 
-Previously, users would complete the flow after connecting a single account, with no clear suggestion to add more. Merchants who connect multiple accounts give their lenders a fuller picture of their cash flow, leading to better lending decisions and improved conversion rates. This addresses a commonly reported pattern where merchants connect only one account.
+    ![Link screen — Add another banking account](/img/updates/260415-link-banking-add-another.png)
 
-The prompt applies to banking integrations connected via both **Plaid** and **TrueLayer**.
+Previously, users completed the flow after connecting a single account and didn't receive a suggestion to add more. The update aims to change this common connection pattern. Merchants who connect multiple accounts give their lenders a fuller picture of their cash flow, which leads to better lending decisions and improves conversion rates. 
+
+The change applies to banking integrations connected via **Plaid** and **TrueLayer**.
 
 ## Who is this relevant for?
 
-All clients using Link — either the [Hosted Link flow](/auth-flow/overview) or the [Link SDK](/auth-flow/authorize-embedded-link) — with banking integrations enabled.
+This change is relevant to all clients using Link with banking integrations enabled. This includes the [Hosted Link flow](/auth-flow/overview) and the [Link SDK](/auth-flow/authorize-embedded-link) solutions.
 
 ## How to get started?
 
-No action is required. The updated flow will be available to all customers using Link with banking integrations from **24 April 2026**.
+No action is required. The updated flow will be available to all customers using Link with banking integrations from **April 24, 2026**.

--- a/static/img/updates/260415-link-banking-add-another.png
+++ b/static/img/updates/260415-link-banking-add-another.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:affcf160974c950ab25f3383e3986ecb77b9932080faa5e4de86f251e4737c24
+size 46035

--- a/static/img/updates/260415-link-banking-plaid-connected.png
+++ b/static/img/updates/260415-link-banking-plaid-connected.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8201d29102d439083fd094f1309469746d4e6dedeadbc86b69f195377640547
+size 65538


### PR DESCRIPTION
## Summary

- New blog post announcing the updated Link flow that encourages users to connect more than one banking account
- Includes two screenshots showing the connection success overlay and the main Link screen
- Scheduled to go live on 24 April 2026

## Test plan

- [x] Blog post renders correctly on the docs site
- [x] Both screenshots display as expected
- [x] Go live date (24 April 2026) is correct in the post and frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)