### PR TITLE
Add blog post announcing CSP nonce support in Link

### DIFF
--- a/blog/260427-csp-nonce-link.md
+++ b/blog/260427-csp-nonce-link.md
@@ -5,11 +5,13 @@ tags: ["Product", "Update", "Link"]
 authors: brettdorrans
 ---
 
-You can now pass a Content Security Policy (CSP) nonce to our Link, Connections, and Bank Feeds SDKs, making it simpler to embed them in apps that enforce strict browser security policies.
+You can now pass a Content Security Policy (CSP) nonce to our Link, Connections, and Bank Feeds SDKs.
 
 <!--truncate-->
 
 ## What's new?
+
+We've made it simpler to embed our SDKs in apps that enforce strict browser security policies.
 
 Our Link SDK now accept a `nonce` option that it applies to every `<style>` tag it injects into your page. This means your app can use a strict CSP `style-src` directive instead of allowing `unsafe-inline`, which previously was required to render the SDK's styles. This option is also available in the Connections and Bank Feeds SDKs, so a single nonce-based CSP can cover all three.
 

--- a/blog/260427-csp-nonce-link.md
+++ b/blog/260427-csp-nonce-link.md
@@ -1,58 +1,48 @@
 ---
-title: "CSP nonce support in Link"
+title: "Codat's SDKs now support CSP"
 date: "2026-04-27"
 tags: ["Product", "Update", "Link"]
 authors: brettdorrans
 ---
 
-You can now pass a Content Security Policy (CSP) nonce to our Link SDK, making it simpler to embed Link in apps that enforce strict browser security policies.
+You can now pass a Content Security Policy (CSP) nonce to our Link, Connections, and Bank Feeds SDKs, making it simpler to embed them in apps that enforce strict browser security policies.
 
 <!--truncate-->
 
 ## What's new?
 
-The Link SDK now accepts a `nonce` option that it applies to every `<style>` tag it injects into your page. With this in place, your app can use a strict CSP `style-src` directive instead of allowing `unsafe-inline`, which previously was required to render Link's styles.
+Our Link SDK now accept a `nonce` option that it applies to every `<style>` tag it injects into your page. This means your app can use a strict CSP `style-src` directive instead of allowing `unsafe-inline`, which previously was required to render the SDK's styles. This option is also available in the Connections and Bank Feeds SDKs, so a single nonce-based CSP can cover all three.
 
-In your `CodatLink` component:
+This change results in the following benefits:
 
-```jsx
-<CodatLink
-  companyId={companyId}
-  options={{ nonce }}
-/>
-```
-
-Then in your CSP header:
-
-```
-style-src 'self' 'nonce-r4nd0mB4se64Val==' *.codat.io;
-```
-
-For full setup steps, including how to generate and surface the nonce, see [CSP nonce](/auth-flow/customize/sdk-customize-code#csp-nonce) in our SDK customization docs.
+- **Stronger browser security:** strict CSPs help protect your customers from cross-site scripting (XSS) attacks. Removing `unsafe-inline` is one of the most impactful changes you can make to your CSP.
+- **Compliance-friendly:** if your security or compliance team has previously flagged `unsafe-inline` in your CSP, this change gives you a clean path to remove it.
+- **No styling trade-offs:** the SDK continues to render with the same look and feel you've configured in the Portal. The nonce only changes how the browser trusts the styles, not the styles themselves.
 
 :::tip Existing setups are unaffected
-If you don't pass a `nonce`, Link works exactly as before. You only need to opt in if you want to remove `unsafe-inline` from your CSP.
+If you don't pass a `nonce` option, the SDKs continue to work as before. You only need to apply the change if you want to remove `unsafe-inline` from your CSP.
 :::
-
-### Why does this matter?
-
-- **Stronger browser security:** Strict CSPs help protect your customers from cross-site scripting (XSS) attacks. Removing `unsafe-inline` is one of the highest-impact changes you can make to your CSP.
-- **Compliance-friendly:** If your security or compliance team has flagged `unsafe-inline` in your CSP, this gives you a clean path to remove it.
-- **No styling trade-offs:** Link continues to render with the same look and feel you've configured in the Portal - the nonce only changes how the browser trusts the styles, not the styles themselves.
-
-The same `nonce` option is also available in the Connections and Bank Feeds SDKs, so a single nonce-based CSP can cover all three.
 
 ## Who is this relevant for?
 
-This update is for clients who embed Link (or Connections, or Bank Feeds) in an app that sets a Content Security Policy, particularly anyone working to remove `unsafe-inline` from their `style-src` directive.
+This update is for clients who embed Codat's SDKs (Link, Connections, or Bank Feeds) in an app that sets a Content Security Policy, especially those working to remove `unsafe-inline` from their `style-src` directive.
 
 ## How to get started?
 
-The `nonce` option is available now. To start using it:
+The `nonce` option is available immediately. To start using it, follow these steps:
 
-1. Configure your server to generate a unique, cryptographically random nonce for each request.
-2. Expose the nonce to the browser, for example via a `<meta>` tag.
-3. Pass the value to the SDK through `options.nonce`.
-4. Update your CSP header to swap `style-src 'unsafe-inline'` for `style-src 'nonce-<value>'`.
+1. Configure your server to generate a unique cryptographically random nonce for each request.
+2. Expose the nonce to the browser (for example, using a `<meta>` tag).
+3. Pass the value to the SDK through `options.nonce`:
+    ```jsx
+    <CodatLink
+      companyId={companyId}
+      options={{ nonce }}
+    />
+    ```
+5. Update your CSP header to swap `style-src 'unsafe-inline'` for `style-src 'nonce-<value>'`.
+    ```
+    style-src 'self' 'nonce-r4nd0mB4se64Val==' *.codat.io;
+    ```
 
-The full migration guide is in our [SDK customization documentation](/auth-flow/customize/sdk-customize-code#csp-nonce).
+The full migration guide and detailed configuration steps are available in [CSP nonce](/auth-flow/customize/sdk-customize-code#csp-nonce) in our SDK documentation.

--- a/blog/260427-csp-nonce-link.md
+++ b/blog/260427-csp-nonce-link.md
@@ -1,0 +1,58 @@
+---
+title: "CSP nonce support in Link"
+date: "2026-04-27"
+tags: ["Product", "Update", "Link"]
+authors: brettdorrans
+---
+
+You can now pass a Content Security Policy (CSP) nonce to our Link SDK, making it simpler to embed Link in apps that enforce strict browser security policies.
+
+<!--truncate-->
+
+## What's new?
+
+The Link SDK now accepts a `nonce` option that it applies to every `<style>` tag it injects into your page. With this in place, your app can use a strict CSP `style-src` directive instead of allowing `unsafe-inline`, which previously was required to render Link's styles.
+
+In your `CodatLink` component:
+
+```jsx
+<CodatLink
+  companyId={companyId}
+  options={{ nonce }}
+/>
+```
+
+Then in your CSP header:
+
+```
+style-src 'self' 'nonce-r4nd0mB4se64Val==' *.codat.io;
+```
+
+For full setup steps, including how to generate and surface the nonce, see [CSP nonce](/auth-flow/customize/sdk-customize-code#csp-nonce) in our SDK customization docs.
+
+:::tip Existing setups are unaffected
+If you don't pass a `nonce`, Link works exactly as before. You only need to opt in if you want to remove `unsafe-inline` from your CSP.
+:::
+
+### Why does this matter?
+
+- **Stronger browser security:** Strict CSPs help protect your customers from cross-site scripting (XSS) attacks. Removing `unsafe-inline` is one of the highest-impact changes you can make to your CSP.
+- **Compliance-friendly:** If your security or compliance team has flagged `unsafe-inline` in your CSP, this gives you a clean path to remove it.
+- **No styling trade-offs:** Link continues to render with the same look and feel you've configured in the Portal - the nonce only changes how the browser trusts the styles, not the styles themselves.
+
+The same `nonce` option is also available in the Connections and Bank Feeds SDKs, so a single nonce-based CSP can cover all three.
+
+## Who is this relevant for?
+
+This update is for clients who embed Link (or Connections, or Bank Feeds) in an app that sets a Content Security Policy, particularly anyone working to remove `unsafe-inline` from their `style-src` directive.
+
+## How to get started?
+
+The `nonce` option is available now. To start using it:
+
+1. Configure your server to generate a unique, cryptographically random nonce for each request.
+2. Expose the nonce to the browser, for example via a `<meta>` tag.
+3. Pass the value to the SDK through `options.nonce`.
+4. Update your CSP header to swap `style-src 'unsafe-inline'` for `style-src 'nonce-<value>'`.
+
+The full migration guide is in our [SDK customization documentation](/auth-flow/customize/sdk-customize-code#csp-nonce).

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -148,6 +148,12 @@ tom-binnington-codat:
   url: https://github.com/tom-binnington-codat
   image_url: https://github.com/tom-binnington-codat.png
 
+brettdorrans:
+  name: Brett Dorrans
+  title: Staff Frontend Engineer
+  url: https://github.com/brettdorrans
+  image_url: https://github.com/brettdorrans.png
+
 a-diarra:
   name: Aïcha Diarra
   title: Head of Support


### PR DESCRIPTION
# Description

Announces the new `nonce` option in the Link, Connections, and Bank Feeds SDKs, which lets clients drop `unsafe-inline` from their CSP `style-src` directive. Builds on the SDK docs added in #1800.

## Type of change

- [X] New document(s)/updating existing

## Test plan

- [x] Local build renders the post correctly (`npm start`)
- [x] Author avatar resolves for `brettdorrans` in `authors.yml`
- [x] In-page link to `/auth-flow/customize/sdk-customize-code#csp-nonce` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)