### PR TITLE
Add developer update: MYOB push operations move to async

### DIFF
--- a/blog/260511-myob-push-operations-async.md
+++ b/blog/260511-myob-push-operations-async.md
@@ -1,0 +1,37 @@
+---
+title: "2026-05-11: MYOB push operations move to async"
+date: "2026-05-07"
+tags: ["Deprecation", "MYOB"]
+authors: annasavinovacodat
+---
+
+On **May 11, 2026**, MYOB push operations will move from synchronous to asynchronous, aligning MYOB with the behaviour of every other Codat integration.
+
+<!--truncate-->
+
+MYOB is currently the only integration where push operations return their final status synchronously. Migrating it to async brings MYOB in line with the rest of our integrations and simplifies our underlying push infrastructure, so we can continue to invest in reliability across the platform.
+
+## What's changing
+
+Today, when you push to MYOB, the API returns a final `Success` or `Failed` status immediately on the initial request.
+
+From **May 11, 2026**, push requests to MYOB will return a `Pending` status on submission, and resolve to `Success` or `Failed` once the operation completes — the same pattern as every other integration.
+
+The change only affects how you confirm the outcome of a push. Pushes themselves will continue to work as before.
+
+## Action required
+
+To track the final status of a push operation to MYOB, use one of the following:
+
+- **Push webhooks** (recommended) — subscribe to the `{dataType}.write.successful` and `{dataType}.write.unsuccessful` events. See [Consume the data types write webhook](/using-the-api/webhooks/event-types).
+- **Status endpoints** — poll the [Get push operation](/platform-api#/operations/get-push-operation) endpoint using the `pushOperationKey` returned in the initial response.
+
+If you already push to other Codat integrations, you'll likely already have this in place.
+
+## Expected impact if no action is taken
+
+If your integration relies on receiving a final `Success` or `Failed` status directly from the initial push response, that status will instead be `Pending` from **May 11, 2026** — and you won't be able to confirm whether the operation ultimately succeeded or failed without consuming the webhook or polling the status endpoint.
+
+Pushes to MYOB will continue to be processed.
+
+If you have questions or need help migrating, reach out to your Codat representative or our support team.

--- a/blog/260511-myob-push-operations-async.md
+++ b/blog/260511-myob-push-operations-async.md
@@ -5,7 +5,7 @@ tags: ["Deprecation", "MYOB"]
 authors: annasavinovacodat
 ---
 
-On **May 11, 2026**, MYOB push operations will move from synchronous to asynchronous, aligning MYOB with the behaviour of every other Codat integration.
+On **May 11, 2026**, MYOB push operations will move from synchronous to asynchronous, aligning MYOB with the behavior of every other Codat integration.
 
 <!--truncate-->
 

--- a/blog/260511-myob-push-operations-async.md
+++ b/blog/260511-myob-push-operations-async.md
@@ -23,8 +23,8 @@ The change only affects how you confirm the outcome of a push. Pushes themselves
 
 To track the final status of a push operation to MYOB, use one of the following:
 
-- **Push webhooks** (recommended) — subscribe to the `{dataType}.write.successful` and `{dataType}.write.unsuccessful` events. See [Consume the data types write webhook](/using-the-api/webhooks/event-types).
-- **Status endpoints** — poll the [Get push operation](/platform-api#/operations/get-push-operation) endpoint using the `pushOperationKey` returned in the initial response.
+- **Push webhooks** (recommended) — subscribe to the `{dataType}.write.successful` and `{dataType}.write.unsuccessful` events. See [Consume the data types write webhook](/using-the-api/push#consume-the-data-types-write-webhook).
+- **Status endpoints** — poll the [Get push operation](/using-the-api/push#monitor-operation-status) endpoint using the `pushOperationKey` returned in the initial response.
 
 If you already push to other Codat integrations, you'll likely already have this in place.
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -159,3 +159,9 @@ a-diarra:
   title: Head of Support
   url: https://github.com/a-diarra
   image_url: https://github.com/a-diarra.png
+
+annasavinovacodat:
+  name: Anna Savinova
+  title: Technical Lead
+  url: https://github.com/annasavinovacodat
+  image_url: https://github.com/annasavinovacodat.png


### PR DESCRIPTION
## Summary

- Adds a developer update announcing the move of MYOB push operations from synchronous to asynchronous on **May 11, 2026**, aligning MYOB with all other Codat integrations.
- Adds Anna Savinova (`annasavinovacodat`) to [blog/authors.yml](blog/authors.yml).

## What changed

- New post: [blog/260511-myob-push-operations-async.md](blog/260511-myob-push-operations-async.md)
- Follows the deprecation-style template (Action required + Expected impact sections), since clients relying on the synchronous final status will need to migrate to webhooks or polling.

## Reviewer notes

- Please verify the link to the write webhook docs (`/using-the-api/webhooks/event-types`) and the `Get push operation` operation link in `/platform-api` resolve to the intended pages.
- Tags used: `Deprecation`, `MYOB`.

## Test plan

- [ ] \`npm run build\` passes
- [ ] Post renders correctly in the blog index and on its own page
- [ ] Author avatar/name resolves for `annasavinovacodat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)