### PR TITLE
Fix multi-entity update link in two Portal blog posts

### DIFF
--- a/blog/260430-portal-subsidiaries-page.md
+++ b/blog/260430-portal-subsidiaries-page.md
@@ -21,7 +21,7 @@ We are introducing the following improvements:
 - Dedicated subsidiaries table reuses the familiar Companies table, including search, sort, connection-status filter, and infinite scroll.
 - Edit, delete, and link actions are available directly from each subsidiary row, matching the behavior on the top-level Companies page.
 
-These improvements apply to all parent companies in the Portal and complement the [hierarchical company table](/blog/multi-entity-portal-update) we shipped earlier this year.
+These improvements apply to all parent companies in the Portal and complement the [hierarchical company table](/updates/260217-multi-entity-portal-update) we shipped earlier this year.
 
 ## Who is this relevant for?
 

--- a/blog/260506-always-visible-search.md
+++ b/blog/260506-always-visible-search.md
@@ -22,7 +22,7 @@ We are introducing the following improvements:
 - Focusing the empty search input opens a popover that lists exactly which fields you can search by: **Company ID**, **Company name**, **Connection ID**, **Connected platform**, and **User who created it**.
 - An updated placeholder ("Search company, platform, ID...") makes the supported search terms clearer at a glance.
 
-These improvements apply to the Companies and Subsidiaries pages and build on the [multi-entity company table](/blog/multi-entity-portal-update) we shipped earlier this year.
+These improvements apply to the Companies and Subsidiaries pages and build on the [multi-entity company table](/updates/260217-multi-entity-portal-update) we shipped earlier this year.
 
 ## Who is this relevant for?
 


### PR DESCRIPTION
## Summary
- Repoint the cross-link in [260430-portal-subsidiaries-page.md](blog/260430-portal-subsidiaries-page.md) and [260506-always-visible-search.md](blog/260506-always-visible-search.md) from the broken `/blog/multi-entity-portal-update` path to the live `/updates/260217-multi-entity-portal-update` URL.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Linkinator passes for both blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)