### PR TITLE
SUP-112: Add status page embed script

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,6 +98,8 @@ const config = {
   organizationName: "codat",
   projectName: "codat-docs",
 
+  scripts: [{ src: "https://status.codat.io/embed/script.js", async: true }],
+
   //onBrokenLinks: 'throw',
   onBrokenLinks: "warn",
   //onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
## Summary
- Adds the Codat status page embed script (`https://status.codat.io/embed/script.js`) via Docusaurus's top-level `scripts` config, loaded async.

## Test plan
- [ ] Verify the status indicator surfaces on docs pages once deployed
- [ ] Confirm no console errors from the embed