### PR TITLE
MED-810: Add Exact UK limitations for Accounts and Invoices

### DIFF
--- a/docs/integrations/accounting/exact-online/exact-online-integration-reference.md
+++ b/docs/integrations/accounting/exact-online/exact-online-integration-reference.md
@@ -32,6 +32,14 @@ You can read the following types of journals from Exact Online:
 
 The `postedOn` field is not populated when reading journal entries from Exact Online. This information is not available from the Exact API.
 
+## Accounts (Exact UK)
+
+When reading Accounts, the `description` and `name` fields return the same value (the account name).
+
+## Invoices (Exact UK)
+
+When reading Invoices, only the `totalDiscount` amount is returned. The `discountPercentage` field is not available.
+
 ## Transfers (Exact UK)
 
 Writing Transfers is only supported for transfers between a bank account and a nominal account of type Balance Sheet.


### PR DESCRIPTION
## Description

Adds two Exact UK-specific limitations to the integration reference page, discovered during mapping improvements (MED-810):

1. **Accounts (Exact UK)**: `description` and `name` fields return the same value (the account name).
2. 2. **Invoices (Exact UK)**: Only `totalDiscount` is returned; `discountPercentage` is not available.
## Type of change

- [x] New document(s)/updating existing