### PR TITLE
DOCS-59 - Remove Go

### DIFF
--- a/src/components/ClientLibraries/index.tsx
+++ b/src/components/ClientLibraries/index.tsx
@@ -28,13 +28,6 @@ const languages = [
     shield: "nuget",
     alt: "Nuget version",
   },
-  {
-    name: "go",
-    namePretty: "Go",
-    icon: "/img/libraries/go.svg",
-    packageLocation: "https://pkg.go.dev/github.com/codatio/client-sdk-go/",
-    alt: "Go version",
-  },
 ];
 
 const capitalizeFirstCharacter = (name: string) =>


### PR DESCRIPTION
Remove the reference to Go Sdk on the libraries page.
