### PR TITLE
docs(lending): add CBS report retention policy to Supported Outputs

### DIFF
--- a/docs/lending/features/bank-statements-overview.md
+++ b/docs/lending/features/bank-statements-overview.md
@@ -203,6 +203,21 @@ if err == nil && statementResponse.StatusCode == 200 {
 
 </Tabs>
 
+#### Report retention
+
+Categorized bank statement reports are subject to two layers of retention:
+
+- **Time-based:** all reports are retained for approximately 90 days from generation, after which they are automatically removed.
+- **Count-based (categorized bank statements only):** only the most recent report is retained. When a new report is generated, the previous report is immediately deleted, even if it is still within the 90-day window.
+
+Because categorized bank statements are cumulative — each report contains all transactions from connected accounts to date — the latest report always includes all data from prior reports. We recommend fetching the most recent report using the [`/latest` endpoint](/lending-api#/operations/get-categorized-bank-statement) rather than storing and re-requesting a specific `reportId`.
+
+:::note 404 on older report IDs
+
+Requesting a superseded `reportId` via `GET /reports/{reportId}` returns a **404** response. This is expected — the report has been removed by the retention policy, not due to an error. Always use `/latest` to reliably retrieve the current report.
+
+:::
+
 ## Get started
 
 Once you have the Lending solution enabled, configure your instance to work with our bank statements feature.

--- a/docs/lending/features/bank-statements-overview.md
+++ b/docs/lending/features/bank-statements-overview.md
@@ -203,21 +203,6 @@ if err == nil && statementResponse.StatusCode == 200 {
 
 </Tabs>
 
-#### Report retention
-
-Categorized bank statement reports are subject to two layers of retention:
-
-- **Time-based:** all reports are retained for approximately 90 days from generation, after which they are automatically removed.
-- **Count-based (categorized bank statements only):** only the most recent report is retained. When a new report is generated, the previous report is immediately deleted, even if it is still within the 90-day window.
-
-Because categorized bank statements are cumulative — each report contains all transactions from connected accounts to date — the latest report always includes all data from prior reports. We recommend fetching the most recent report using the [`/latest` endpoint](/lending-api#/operations/get-categorized-bank-statement) rather than storing and re-requesting a specific `reportId`.
-
-:::note 404 on older report IDs
-
-Requesting a superseded `reportId` via `GET /reports/{reportId}` returns a **404** response. This is expected — the report has been removed by the retention policy, not due to an error. Always use `/latest` to reliably retrieve the current report.
-
-:::
-
 ## Get started
 
 Once you have the Lending solution enabled, configure your instance to work with our bank statements feature.

--- a/docs/lending/features/excel-download-overview.md
+++ b/docs/lending/features/excel-download-overview.md
@@ -219,7 +219,7 @@ You can also generate and download the **data export** report by clicking the **
 
 #### Report retention
 
-Categorized bank statement reports are subject to two layers of retention:
+Lending reports are subject to two layers of retention:
 
 - **Time-based:** all reports are retained for approximately 90 days from generation, after which they are automatically removed.
 - **Count-based (categorized bank statements only):** only the most recent report is retained. When a new report is generated, the previous report is immediately deleted, even if it is still within the 90-day window.

--- a/docs/lending/features/excel-download-overview.md
+++ b/docs/lending/features/excel-download-overview.md
@@ -216,7 +216,6 @@ You can also generate and download a report in an Excel format via the [Portal](
 
 You can also generate and download the **data export** report by clicking the **Export data** button on any of the Lending screens of the Portal.
 
-
 #### Report retention
 
 Lending reports are subject to two layers of retention:
@@ -231,6 +230,7 @@ Because categorized bank statements are cumulative — each report contains all 
 Requesting a superseded `reportId` via `GET /reports/{reportId}` returns a **404** response. This is expected — the report has been removed by the retention policy, not due to an error. Always use `/latest` to reliably retrieve the current report.
 
 :::
+
 ---
 
 ## Read next

--- a/docs/lending/features/excel-download-overview.md
+++ b/docs/lending/features/excel-download-overview.md
@@ -216,6 +216,21 @@ You can also generate and download a report in an Excel format via the [Portal](
 
 You can also generate and download the **data export** report by clicking the **Export data** button on any of the Lending screens of the Portal.
 
+
+#### Report retention
+
+Categorized bank statement reports are subject to two layers of retention:
+
+- **Time-based:** all reports are retained for approximately 90 days from generation, after which they are automatically removed.
+- **Count-based (categorized bank statements only):** only the most recent report is retained. When a new report is generated, the previous report is immediately deleted, even if it is still within the 90-day window.
+
+Because categorized bank statements are cumulative — each report contains all transactions from connected accounts to date — the latest report always includes all data from prior reports. We recommend fetching the most recent report using the [`/latest` endpoint](/lending-api#/operations/get-categorized-bank-statement) rather than storing and re-requesting a specific `reportId`.
+
+:::note 404 on older report IDs
+
+Requesting a superseded `reportId` via `GET /reports/{reportId}` returns a **404** response. This is expected — the report has been removed by the retention policy, not due to an error. Always use `/latest` to reliably retrieve the current report.
+
+:::
 ---
 
 ## Read next


### PR DESCRIPTION
Documents the two-layer retention behaviour for categorized bank statement reports:
- Time-based: ~90-day window for all report types
- Count-based (CBS only): only the latest report is retained; previous reports are removed when a new one is generated

Includes guidance to use /latest endpoint and explains expected 404 behaviour on superseded reportIds.

Refs: MED-814
