### PR TITLE
FOR-857: Xero duplicate FeedConnection prevention update

### DIFF
--- a/blog/260623-xero-duplicate-feedconnection-prevention.md
+++ b/blog/260623-xero-duplicate-feedconnection-prevention.md
@@ -1,0 +1,49 @@
+---
+title: "Improved validation for Xero bank feed account mapping"
+date: "2026-06-23"
+tags: ["Product", "Update", "Bank feeds", "Xero"]
+authors: Huweey
+---
+
+We are improving how Xero bank feed accounts are mapped to prevent the same Xero bank account being connected under more than one company that shares the same Xero application.
+
+<!--truncate-->
+
+## What's new?
+
+Today it's possible to create a duplicate mapping where the target Xero bank account is already connected to a different company using the same Xero application. When that happens, multiple source accounts across different companies point to the same Xero bank feed, making it unclear which is the true source of data.
+
+This update introduces two improvements:
+
+- **Validation**: when a target Xero bank account is already connected under a different company, the mapping request now returns a clear `400` error with a suggested resolution, instead of silently creating a duplicate.
+- **Filtered options**: target Xero bank accounts already connected to a bank feed under any company using the same Xero app are excluded from the available mapping options.
+
+If a source account is already mapped to a Xero target account, attempting to create the same mapping again still succeeds without errors. That behaviour is unchanged. Existing mappings are not modified.
+
+### Xero API limitation
+
+Xero's API only shows feed connections that share the same OAuth application. If a target account is already connected through a *different* Xero OAuth application, it still appears as available. The mapping attempt then fails with an error explaining that the account is already in use.
+
+## Who is this relevant for?
+
+This change is relevant for Xero bank feeds clients whose setup meets **all** of the following:
+
+1. Multiple companies share the same Xero OAuth application.
+2. Those companies connect to the same Xero organization.
+3. A user tries to map a source account to a Xero target account already used by a different company.
+
+## How to get started?
+
+**No changes to your integration are required.** Once the update is live, you will see:
+
+- Target accounts already connected under another company using the same Xero application no longer appear in the available mapping options.
+- Target accounts connected through a different Xero application still appear, but attempts to map them return an error.
+
+### Remapping a Xero bank account
+
+If a customer needs to remap a Xero bank account:
+
+1. Remove the existing bank feed connection that uses the account. This makes the target account available again.
+2. Create a new mapping to the required company.
+
+Contact Codat Support or your Account Manager if you'd like help with this change.

--- a/blog/260624-xero-duplicate-feedconnection-prevention.md
+++ b/blog/260624-xero-duplicate-feedconnection-prevention.md
@@ -26,7 +26,7 @@ This update takes effect on **24 June 2026**.
 
 ### Xero API limitation
 
-Xero's API only shows feed connections that share the same OAuth application. If a target account is already connected through a *different* Xero OAuth application, it still appears as available. The mapping attempt then fails with an error explaining that the account is already in use.
+Xero's API only shows feed connections that share the same OAuth application. If a target account is already connected through a _different_ Xero OAuth application, it still appears as available. The mapping attempt then fails with an error explaining that the account is already in use.
 
 ## Who is this relevant for?
 

--- a/blog/260624-xero-duplicate-feedconnection-prevention.md
+++ b/blog/260624-xero-duplicate-feedconnection-prevention.md
@@ -1,6 +1,6 @@
 ---
 title: "Improved validation for Xero bank feed account mapping"
-date: "2026-06-23"
+date: "2026-06-24"
 tags: ["Product", "Update", "Bank feeds", "Xero"]
 authors: Huweey
 ---
@@ -19,6 +19,10 @@ This update introduces two improvements:
 - **Filtered options**: target Xero bank accounts already connected to a bank feed under any company using the same Xero app are excluded from the available mapping options.
 
 If a source account is already mapped to a Xero target account, attempting to create the same mapping again still succeeds without errors. That behaviour is unchanged. Existing mappings are not modified.
+
+### When does this take effect?
+
+This update takes effect on **24 June 2026**.
 
 ### Xero API limitation
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -6,7 +6,7 @@ codat-bot:
 
 Huweey:
   name: Huw Thomas
-  title: Engineer
+  title: Software Engineer
   url: https://github.com/Huweey
   image_url: https://github.com/Huweey.png
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -4,6 +4,12 @@ codat-bot:
   url: https://github.com/codat-engineering
   image_url: https://github.com/codat-engineering.png
 
+Huweey:
+  name: Huw Thomas
+  title: Engineer
+  url: https://github.com/Huweey
+  image_url: https://github.com/Huweey.png
+
 mcclowes:
   name: Max Clayton Clowes
   title: Product Director, Client Experience

--- a/docs/integrations/accounting/xero/xero-app-partner-program.md
+++ b/docs/integrations/accounting/xero/xero-app-partner-program.md
@@ -35,6 +35,6 @@ We recommend working closely with Codat to ensure Xero’s technical requirement
 
 #### Xero’s commercial framework
 
-For App Store partners Xero offers a [tiered pricing model based on connections and API usage](https://developer.xero.com/pricing). 
+For App Store partners Xero offers a [tiered pricing model based on connections and API usage](https://developer.xero.com/pricing).
 
 For Financial Services Partners a separate commercial model is in place. For guidance on Xero fees, please speak to your Codat account manager.


### PR DESCRIPTION
## Summary

[FOR-857](https://codatdocs.atlassian.net/browse/FOR-857). Adds a `/updates` post announcing improved validation for Xero bank feed account mapping (duplicate FeedConnection prevention). Goes live 24 June 2026 — before FOR-854/FOR-855 deploy.

## What was added

- `blog/260624-xero-duplicate-feedconnection-prevention.md` — the update post
- `blog/authors.yml` — author entry for Huw Thomas

## Also included

- Stripped a stray trailing space in `docs/integrations/accounting/xero/xero-app-partner-program.md`. It was failing the `markdown-format` check on every PR (already red on `main`, e.g. PR #1854); unrelated to this update but fixed here to get CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FOR-857]: https://codatdocs.atlassian.net/browse/FOR-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ