### PR TITLE
PEP-1751: Deprecation notice for connectionManagement/accessToken endpoint

### DIFF
--- a/blog/260623-deprecation-connection-management-access-token.md
+++ b/blog/260623-deprecation-connection-management-access-token.md
@@ -1,0 +1,55 @@
+---
+title: "Upcoming YYYY-MM-DD: Deprecation of the connection management access token endpoint"
+date: "2026-06-23"
+tags: ["Deprecation"]
+draft: true
+authors: rachelcodat
+---
+
+<!--
+TODO before publishing:
+  1. Agree the sunset date with the team (PEP-1751 acceptance criteria), following the
+     deprecation schedule in the change policy:
+     https://docs.codat.io/introduction/change-policy#deprecation-schedule
+  2. Replace every YYYY-MM-DD placeholder below (title + body) with the agreed date.
+  3. Set `date` to the publication date.
+  4. Remove the `draft: true` line.
+  5. Confirm with #team-documentation before publishing.
+-->
+
+On YYYY-MM-DD, Codat will deprecate the `connectionManagement/accessToken` endpoint used to generate company-specific connection management access tokens.
+
+<!--truncate-->
+
+Codat now supports a single, global company access token that provides seamless access across multiple products. To improve efficiency and consistency, we are deprecating the older connection-management-specific endpoint in favour of this global token.
+
+The following endpoint will be deprecated:
+
+```http
+GET /companies/{companyId}/connectionManagement/accessToken
+```
+
+## Action required
+
+If you are using the endpoint above, you will need to instead use the global company access token endpoint:
+
+```http
+GET /companies/{companyId}/accessToken
+```
+
+The replacement endpoint returns an access token in the same way and requires no additional configuration. Update your integration to call the new endpoint ahead of the deprecation date.
+
+## Expected impact if no action is taken
+
+After YYYY-MM-DD, calls to the deprecated endpoint will return a `404` error.
+
+```json
+{
+  "statusCode": 404,
+  "service": "PublicApi",
+  "error": "NotFound",
+  "correlationId": "2b60a2bafedd3238702c2186a2dc833f",
+  "canBeRetried": "Unknown",
+  "detailedErrorCode": 0
+}
+```

--- a/blog/260623-deprecation-connection-management-access-token.md
+++ b/blog/260623-deprecation-connection-management-access-token.md
@@ -1,5 +1,5 @@
 ---
-title: "Upcoming YYYY-MM-DD: Deprecation of the connection management access token endpoint"
+title: "Upcoming 2026-10-12: Deprecation of the connection management access token endpoint"
 date: "2026-06-23"
 tags: ["Deprecation"]
 draft: true
@@ -8,16 +8,18 @@ authors: rachelcodat
 
 <!--
 TODO before publishing:
-  1. Agree the sunset date with the team (PEP-1751 acceptance criteria), following the
-     deprecation schedule in the change policy:
-     https://docs.codat.io/introduction/change-policy#deprecation-schedule
-  2. Replace every YYYY-MM-DD placeholder below (title + body) with the agreed date.
-  3. Set `date` to the publication date.
-  4. Remove the `draft: true` line.
+  1. Confirm the 2026-10-12 sunset date with the team (PEP-1751 acceptance criteria).
+     This is the Q4 2026 enforcement date (first working day on/after Sat 10 Oct).
+     The changelog entry MUST be live before the early-July quarterly developer email
+     (practically ~7 July 2026) to make the Q4 window; otherwise the next date is
+     2027-01-11. See https://docs.codat.io/using-the-api/change-policy#deprecation-schedule
+  2. Set `date` to the publication date.
+  3. Remove the `draft: true` line.
+  4. Add a corresponding entry to the deprecations Google Calendar.
   5. Confirm with #team-documentation before publishing.
 -->
 
-On YYYY-MM-DD, Codat will deprecate the `connectionManagement/accessToken` endpoint used to generate company-specific connection management access tokens.
+On 2026-10-12, Codat will deprecate the `connectionManagement/accessToken` endpoint used to generate company-specific connection management access tokens.
 
 <!--truncate-->
 
@@ -41,7 +43,7 @@ The replacement endpoint returns an access token in the same way and requires no
 
 ## Expected impact if no action is taken
 
-After YYYY-MM-DD, calls to the deprecated endpoint will return a `404` error.
+After 2026-10-12, calls to the deprecated endpoint will return a `404` error.
 
 ```json
 {

--- a/blog/260623-deprecation-connection-management-access-token.md
+++ b/blog/260623-deprecation-connection-management-access-token.md
@@ -25,7 +25,7 @@ If you are using the endpoint above, you will need to instead use the global com
 GET /companies/{companyId}/accessToken
 ```
 
-The replacement endpoint returns an access token in the same way and requires no additional configuration. Update your integration to call the new endpoint ahead of the deprecation date.
+The access token is returned in the same `accessToken` field, so if you read that field you can switch to the new endpoint with no further changes. The replacement response additionally includes `expiresIn` (seconds until the token expires) and `tokenType` (for example, `Bearer`). Update your integration to call the new endpoint ahead of the deprecation date.
 
 ## Expected impact if no action is taken
 

--- a/blog/260623-deprecation-connection-management-access-token.md
+++ b/blog/260623-deprecation-connection-management-access-token.md
@@ -2,22 +2,8 @@
 title: "Upcoming 2026-10-12: Deprecation of the connection management access token endpoint"
 date: "2026-06-23"
 tags: ["Deprecation"]
-draft: true
 authors: rachelcodat
 ---
-
-<!--
-TODO before publishing:
-  1. Confirm the 2026-10-12 sunset date with the team (PEP-1751 acceptance criteria).
-     This is the Q4 2026 enforcement date (first working day on/after Sat 10 Oct).
-     The changelog entry MUST be live before the early-July quarterly developer email
-     (practically ~7 July 2026) to make the Q4 window; otherwise the next date is
-     2027-01-11. See https://docs.codat.io/using-the-api/change-policy#deprecation-schedule
-  2. Set `date` to the publication date.
-  3. Remove the `draft: true` line.
-  4. Add a corresponding entry to the deprecations Google Calendar.
-  5. Confirm with #team-documentation before publishing.
--->
 
 On 2026-10-12, Codat will deprecate the `connectionManagement/accessToken` endpoint used to generate company-specific connection management access tokens.
 

--- a/blog/260624-deprecation-connection-management-access-token.md
+++ b/blog/260624-deprecation-connection-management-access-token.md
@@ -1,6 +1,6 @@
 ---
 title: "Upcoming 2026-10-12: Deprecation of the connection management access token endpoint"
-date: "2026-06-23"
+date: "2026-06-24"
 tags: ["Deprecation"]
 authors: rachelcodat
 ---


### PR DESCRIPTION
## What

Adds a docs.codat.io changelog/blog entry announcing the deprecation of the public client route `GET /companies/{companyId}/connectionManagement/accessToken` in favour of the global `GET /companies/{companyId}/accessToken` endpoint.

Previously the only deprecation signal was the OAS `deprecated: true` marker (in `codat-internal/oas`, `Codat-Platform.yaml`) — no changelog or docs notice. This PR provides the published changelog notice required by [PEP-1751](https://codatdocs.atlassian.net/browse/PEP-1751).

## Sunset date

**2026-10-12** — the Q4 2026 enforcement date (first working day on/after Sat 10 Oct), per the [change-policy deprecation schedule](https://docs.codat.io/using-the-api/change-policy#deprecation-schedule).

To land in the Q4 window this needs to be **merged + live before the early-July quarterly developer email** (~7 July 2026). If it slips past that, the date must move to the next quarter (2027-01-11).

## Follow-ups (after merge — also add a deprecations Google Calendar entry)

- **API-docs notice beyond the spec marker** — enhancing the endpoint description copy in the `oas` repo (`reference/common/copy/connection-management/get-access-token.md`) so the deprecation renders prominently on the API reference page.
- **Direct customer outreach** to Toast (`4ba960c6`) and Bill360 (`0059aab6`) with the replacement endpoint + migration guidance.

Source: PEP-1632 auth-merge spike, Area 1b / 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PEP-1751]: https://codatdocs.atlassian.net/browse/PEP-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ