### PR TITLE
EXP-1609: Migrate deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build site
+        run: npm run build
+        env:
+          ZENDESK_KEY: ${{ secrets.ZENDESK_KEY }}
+          AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
+          GTM_ID: ${{ vars.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}
+
+      - uses: actions/configure-pages@v6
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,9 @@ jobs:
         env:
           ZENDESK_KEY: ${{ secrets.ZENDESK_KEY }}
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
-          GTM_ID: ${{ secrets.GTM_ID }}
-          FEATURE_DEV_FLAG: ${{ secrets.FEATURE_DEV_FLAG }}
-          FEATURE_NEW_PRODUCTS_FLAG: ${{ secrets.FEATURE_NEW_PRODUCTS_FLAG }}
+          GTM_ID: ${{ vars.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}
 
       - uses: actions/configure-pages@v6
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,9 +35,9 @@ jobs:
         env:
           ZENDESK_KEY: ${{ secrets.ZENDESK_KEY }}
           AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
-          GTM_ID: ${{ vars.GTM_ID }}
-          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
-          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}
+          GTM_ID: ${{ secrets.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ secrets.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ secrets.FEATURE_NEW_PRODUCTS_FLAG }}
 
       - uses: actions/configure-pages@v6
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,6 @@ jobs:
         run: npm run build
         env:
           # plugin-google-gtag requires a trackingID, so PR builds need it too
-          GTM_ID: ${{ vars.GTM_ID }}
-          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
-          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}
+          GTM_ID: ${{ secrets.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ secrets.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ secrets.FEATURE_NEW_PRODUCTS_FLAG }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,30 @@
+name: PR build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      # The ADO registry in .npmrc requires auth even to install, so PR
+      # builds need NPM_TOKEN too (fork PRs don't get secrets and will fail)
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Build site
+        run: npm run build
+        env:
+          # plugin-google-gtag requires a trackingID, so PR builds need it too
+          GTM_ID: ${{ vars.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,6 +25,6 @@ jobs:
         run: npm run build
         env:
           # plugin-google-gtag requires a trackingID, so PR builds need it too
-          GTM_ID: ${{ secrets.GTM_ID }}
-          FEATURE_DEV_FLAG: ${{ secrets.FEATURE_DEV_FLAG }}
-          FEATURE_NEW_PRODUCTS_FLAG: ${{ secrets.FEATURE_NEW_PRODUCTS_FLAG }}
+          GTM_ID: ${{ vars.GTM_ID }}
+          FEATURE_DEV_FLAG: ${{ vars.FEATURE_DEV_FLAG }}
+          FEATURE_NEW_PRODUCTS_FLAG: ${{ vars.FEATURE_NEW_PRODUCTS_FLAG }}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -262,8 +262,6 @@ const config = {
         anonymizeIP: true,
       },
     ],
-
-    "vercel-analytics",
   ],
 
   themes: ["@docusaurus/theme-mermaid", "docusaurus-theme-search-typesense"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@codat/sdk-link-types": "1.10.1",
         "@docusaurus/core": "3.9.2",
         "@docusaurus/plugin-client-redirects": "3.9.2",
-        "@docusaurus/plugin-vercel-analytics": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
         "@docusaurus/theme-live-codeblock": "3.9.2",
         "@docusaurus/theme-mermaid": "3.9.2",
@@ -4639,28 +4638,6 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-vercel-analytics": {
-      "version": "3.9.2",
-      "resolved": "https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/@docusaurus/plugin-vercel-analytics/-/plugin-vercel-analytics-3.9.2.tgz",
-      "integrity": "sha1-YatIFDyr6yBWdjdWW/e9kGMUoMo=",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@vercel/analytics": "^1.1.1",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@docusaurus/preset-classic": {
       "version": "3.9.2",
       "resolved": "https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
@@ -9074,44 +9051,6 @@
       "resolved": "https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha1-0Gu7OE689sUF/eHD0O1N3/4Kr/g=",
       "license": "ISC"
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/@vercel/analytics/-/analytics-1.6.1.tgz",
-      "integrity": "sha1-tOFtr0Rc9s02WpHkPYbp5bNCjdw=",
-      "license": "MPL-2.0",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@codat/sdk-link-types": "1.10.1",
     "@docusaurus/core": "3.9.2",
     "@docusaurus/plugin-client-redirects": "3.9.2",
-    "@docusaurus/plugin-vercel-analytics": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/theme-live-codeblock": "3.9.2",
     "@docusaurus/theme-mermaid": "3.9.2",

--- a/src/theme/NavbarItem/index.tsx
+++ b/src/theme/NavbarItem/index.tsx
@@ -4,7 +4,6 @@ import NavbarIconLink from "@theme/NavbarItem/NavbarIconLink";
 import NavbarSeparator from "@theme/NavbarItem/NavbarSeparator";
 import NavbarCta from "@theme/NavbarItem/NavbarCta";
 
-import { track } from "@vercel/analytics";
 import { trackEvent } from "../../utils/amplitude";
 
 const CustomNavbarItemComponents = {
@@ -18,7 +17,6 @@ export default function NavbarItem(props) {
 
   const onTrack = () => {
     if (props.label === "Sign in") {
-      track("Sign in");
       trackEvent("Navigation Click", {
         element: "Sign in",
         type: "navbar_cta",

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs.codat.io


### PR DESCRIPTION
## What

Migrates docs.codat.io deployment from Vercel to GitHub Pages ([EXP-1609](https://codatdocs.atlassian.net/browse/EXP-1609), part of the Vercel migration workstream). Follows the pattern proven on legal.codat.io (codatio/legal#74) and the engineering blog.

- **`.github/workflows/deploy.yml`** — on push to `main`: Node 24, `npm ci` (ADO feed via `NPM_TOKEN`), `docusaurus build`, publish to GitHub Pages. No `fetch-depth: 0` needed — this site doesn't use `showLastUpdateAuthor/Time`.
- **`.github/workflows/pr.yml`** — build-only PR check. This replaces Vercel preview deployments (tradeoff acked by the docs team).
- **`static/CNAME`** — `docs.codat.io` for the custom domain.
- **Removed `@docusaurus/plugin-vercel-analytics`** (plugin + dependency). Lockfile was edited by hand (leaf dependency; `@vercel/oidc` stays — it belongs to `@ai-sdk/gateway`); the `npm ci` in this PR's own check validates it.

## Deliberately NOT in this PR

- **`vercel.json` stays** — Vercel keeps auto-deploying prod from `main` until decommission, and it carries the live CORS headers on `/updates/rss.xml`. It gets deleted in a cleanup PR after cutover.
- The `vercel.json` redirect (`/docs/angular/your-first-app/2-taking-photos`) was **not ported** to `plugin-client-redirects`: neither source nor target exists anywhere in the repo — it's an Ionic-template leftover.
- DNS cutover is a separate infrastructure-as-code PR.

## Before merging

- [x] Repo **secrets** set (27 Jul): `NPM_TOKEN`, `ZENDESK_KEY`, `AMPLITUDE_API_KEY`, `GTM_ID`, `FEATURE_DEV_FLAG`, `FEATURE_NEW_PRODUCTS_FLAG` (all captured from Vercel; `GA_ID` also copied over but unused by the code)
- [x] Workflows read all env vars from secrets
- [ ] Org setting `members_can_create_public_pages` enabled (needed at site-creation time)
- [ ] Repo Settings → Pages → Source: **GitHub Actions**
- [x] `/updates/rss.xml` CORS consumer: **resolved** — the only consumer is portal-ui's "What's New" fetch (app.codat.io), a plain `axios.get` with no custom headers since Datadog RUM was removed from portal-ui in Sep 2025 (PEP-141). No preflight is sent; GitHub Pages' default `access-control-allow-origin: *` suffices. The x-datadog allow-headers in vercel.json are dead config.

After merge, the site at `codatio.github.io/codat-docs` will look broken with a "wrong baseUrl" banner — **expected**, it's built for docs.codat.io. Then set the custom domain in Pages settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-1609]: https://codatdocs.atlassian.net/browse/EXP-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ