### PR TITLE
EXP-1609: Fix broken images — fetch Git LFS content in checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Images are Git LFS-tracked (.gitattributes); without this the
+          # build ships LFS pointer files instead of the actual binaries
+          lfs: true
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Images are Git LFS-tracked (.gitattributes); without this the
+          # build ships LFS pointer files instead of the actual binaries
+          lfs: true
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
All site images are currently serving as Git LFS pointer files on docs.codat.io (e.g. `/logos/codat-docs-dark.png` is 130 bytes of pointer text) because `actions/checkout` doesn't fetch LFS content by default. Vercel handled this via `git_lfs = true` in its project config; the equivalent here is `lfs: true` on checkout in both workflows.

Also explains the `unsupported file type` warnings in earlier CI builds — `image-size` reading pointer files.

Merging triggers a redeploy that restores all images. Part of [EXP-1609](https://codatdocs.atlassian.net/browse/EXP-1609).

⚠️ Watch item: Actions LFS pulls count against the repo's LFS bandwidth quota (Vercel's didn't). If builds are frequent enough to matter, a follow-up can cache LFS objects between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EXP-1609]: https://codatdocs.atlassian.net/browse/EXP-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ