### PR TITLE
Document FreeAgent bank feeds transaction direction

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -242,6 +242,7 @@
     "XLSB",
     "Xero's",
     "Xero",
+    "Xfer",
     "YNAB",
     "Yundt",
     "yzth",

--- a/docs/bank-feeds/pushing-transactions.md
+++ b/docs/bank-feeds/pushing-transactions.md
@@ -19,7 +19,7 @@ Collect transaction data within your own application and map it to Codat's [Bank
 :::caution Transaction signs
 Make sure the transaction `amount` signs align with the `transactionType`. Codat issues a warning for inconsistencies, such as a `Debit` transaction with a positive amount.
 
-Some accounting platforms take the direction of a transaction from its `transactionType` rather than the sign of the `amount`. FreeAgent works this way, and Codat adjusts the transaction so the sign you send is honored. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
+Some accounting platforms take the direction of a transaction from its `transactionType` rather than the sign of the `amount`. FreeAgent works this way for some types, and Codat adjusts transfers so the sign you send is honored. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
 :::
 
 ## Write bank transactions

--- a/docs/bank-feeds/pushing-transactions.md
+++ b/docs/bank-feeds/pushing-transactions.md
@@ -19,7 +19,7 @@ Collect transaction data within your own application and map it to Codat's [Bank
 :::caution Transaction signs
 Make sure the transaction `amount` signs align with the `transactionType`. Codat issues a warning for inconsistencies, such as a `Debit` transaction with a positive amount.
 
-Some accounting platforms take the direction of a transaction from its `transactionType` rather than the sign of the `amount`. FreeAgent works this way for some types, and Codat adjusts transfers so the sign you send is honored. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
+Some accounting platforms take the direction of a transaction from its `transactionType` rather than the sign of the `amount`. FreeAgent works this way for some types, and Codat adjusts transfers to honor the sign you send. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
 :::
 
 ## Write bank transactions

--- a/docs/bank-feeds/pushing-transactions.md
+++ b/docs/bank-feeds/pushing-transactions.md
@@ -18,6 +18,8 @@ Collect transaction data within your own application and map it to Codat's [Bank
 
 :::caution Transaction signs
 Make sure the transaction `amount` signs align with the `transactionType`. Codat issues a warning for inconsistencies, such as a `Debit` transaction with a positive amount.
+
+Some accounting platforms take the direction of a transaction from its `transactionType` rather than the sign of the `amount`. FreeAgent works this way, and Codat adjusts the transaction so the sign you send is honored. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
 :::
 
 ## Write bank transactions

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -38,7 +38,7 @@ Because a positive `Xfer` is written as `OTHER`, the SMB user sees `//OTHER/` in
 your-transaction-description//OTHER/£1.60
 ```
 
-## SMB users explain the transfer themselves
+### SMB users explain the transfer themselves
 
 Because the transaction arrives as `OTHER` rather than `Xfer`, FreeAgent doesn't suggest a transfer when your SMB user explains it.
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -6,35 +6,29 @@ description: "Learn how to write your SMB users' bank transactions via our FreeA
 
 When an SMB user has set up a bank feed connection, you can write bank transactions for source bank accounts to FreeAgent. Write them using the [Create bank transactions](/bank-feeds-api#/operations/create-bank-transactions) endpoint, as described in [Write transactions](/bank-feeds/pushing-transactions).
 
-This article explains how FreeAgent decides whether a transaction is money in or money out, because it differs from other bank feeds integrations.
+This article explains how FreeAgent decides whether a transfer is money in or money out, because it differs from other bank feeds integrations.
 
 ## Prerequisites
 
 - Your SMB user has an authorized FreeAgent connection and has [established a bank feed](/bank-feeds/mapping/overview).
 
-## Transaction direction comes from the type
+## Transaction direction can come from the type
 
 In Codat's bank transactions schema, the sign of the `amount` determines the direction of a transaction: positive is money in, negative is money out. The `transactionType` describes the kind of transaction.
 
-FreeAgent takes the direction from the `transactionType` instead, and overrides the sign of the `amount` for most types.
+For some transaction types, FreeAgent takes the direction from the `transactionType` and overrides the sign of the `amount`. `Xfer` is one of these types: FreeAgent always treats a transfer as money out.
 
-| FreeAgent behavior | Transaction types                                                                        |
-| ------------------ | ---------------------------------------------------------------------------------------- |
-| Always money out   | `Debit`, `Fee`, `SerChg`, `Xfer`, `Check`, `Payment`, `Cash`, `DirectDebit`, `RepeatPmt` |
-| Always money in    | `Credit`, `Div`, `Dep`, `DirectDep`                                                      |
-| Uses the sign      | `Int`, `Atm`, `Pos`, `Other`, `Unknown`                                                  |
-
-So for a transaction sent as `amount: 1.60` with `transactionType: Xfer`, FreeAgent records £1.60 out, while integrations that use the sign, such as Xero and QuickBooks Online, record £1.60 in.
+Written as sent, a transaction with `amount: 1.60` and `transactionType: Xfer` would be £1.60 out in FreeAgent, while integrations that use the sign, such as Xero and QuickBooks Online, record £1.60 in.
 
 ## Codat converts a positive transfer
 
 To keep the direction consistent with the `amount` you send, Codat writes a positive `Xfer` transaction to FreeAgent as `OTHER`. FreeAgent uses the sign for `OTHER` in both directions, so the transaction is recorded as money in, matching the sign of the `amount`.
 
-A negative `Xfer` isn't converted, because the type and the sign already agree. Codat converts no other type, but it does rename `SerChg` to FreeAgent's `SRVCHG` and writes `Unknown` as `OTHER`, neither of which changes the direction.
+A negative `Xfer` isn't converted, because the type and the sign already agree.
 
-:::caution Other conflicting types aren't converted
+:::caution Only transfers are converted
 
-Codat only converts `Xfer`. If you send a positive amount with any other type in the **Always money out** group, FreeAgent records it as money out. Send those transactions with a type that matches the direction you want, or use `OTHER`.
+Codat converts `Xfer` only. Other types that FreeAgent treats the same way aren't converted, so a positive amount can still be recorded as money out. Where the direction matters, send a `transactionType` that matches it, or use `OTHER`.
 
 :::
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -30,7 +30,7 @@ A negative `Xfer` isn't converted, because the type and the sign already agree.
 
 Because a converted transaction arrives with a general type rather than the transfer label, FreeAgent doesn't suggest a transfer when your SMB user explains it.
 
-They can still explain it as a transfer exactly as they do now. They select it themselves instead of FreeAgent proposing it.
+They can still explain it as a transfer exactly as they do now, using the **Transfer to Another Account** option. They select it themselves instead of FreeAgent proposing it.
 
 ## The type appears in the description
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -26,12 +26,6 @@ To keep the direction consistent with the `amount` you send, Codat writes a posi
 
 A negative `Xfer` isn't converted, because the type and the sign already agree.
 
-:::caution Only transfers are converted
-
-Codat converts `Xfer` only. Other types that FreeAgent treats the same way aren't converted, so a positive amount can still be recorded as money out. Where the direction matters, send a `transactionType` that matches it, or use `OTHER`.
-
-:::
-
 ## The type appears in the description
 
 FreeAgent includes the transaction type in the description that the SMB user sees against the bank transaction. A transaction sent as `Xfer` reads as `//XFER/`, followed by the amount:

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -26,6 +26,12 @@ To keep the direction consistent with the `amount` you send, Codat writes a posi
 
 A negative `Xfer` isn't converted, because the type and the sign already agree.
 
+## SMB users explain the transfer themselves
+
+Because a converted transaction arrives with a general type rather than the transfer label, FreeAgent doesn't suggest a transfer when your SMB user explains it.
+
+They can still explain it as a transfer exactly as they do now. They select it themselves instead of FreeAgent proposing it.
+
 ## The type appears in the description
 
 FreeAgent includes the transaction type in the description that the SMB user sees against the bank transaction. A transaction sent as `Xfer` reads as `//XFER/`, followed by the amount:

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -24,7 +24,7 @@ To keep the direction consistent with the `amount` you send, Codat writes a posi
 
 A negative `Xfer` isn't converted, because the type and the sign already agree.
 
-## The type appears in the description
+### The type appears in the description
 
 FreeAgent includes the transaction type in the description that the SMB user sees against the bank transaction. A transaction sent as `Xfer` reads as `//XFER/`, followed by the amount:
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -44,4 +44,4 @@ your-transaction-description//OTHER/£1.60
 
 Because the transaction arrives as `OTHER` rather than `Xfer`, FreeAgent doesn't suggest a transfer when your SMB user explains it.
 
-They can still explain it as a transfer exactly as they do now, using the **Transfer to Another Account** option. They select it themselves instead of FreeAgent proposing it.
+They can still explain it as a transfer exactly as they do now, using the **Transfer from Another Account** option. They select it themselves instead of FreeAgent proposing it.

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -26,12 +26,6 @@ To keep the direction consistent with the `amount` you send, Codat writes a posi
 
 A negative `Xfer` isn't converted, because the type and the sign already agree.
 
-## SMB users explain the transfer themselves
-
-Because a converted transaction arrives with a general type rather than the transfer label, FreeAgent doesn't suggest a transfer when your SMB user explains it.
-
-They can still explain it as a transfer exactly as they do now, using the **Transfer to Another Account** option. They select it themselves instead of FreeAgent proposing it.
-
 ## The type appears in the description
 
 FreeAgent includes the transaction type in the description that the SMB user sees against the bank transaction. A transaction sent as `Xfer` reads as `//XFER/`, followed by the amount:
@@ -45,3 +39,9 @@ Because a positive `Xfer` is written as `OTHER`, the SMB user sees `//OTHER/` in
 ```text
 your-transaction-description//OTHER/£1.60
 ```
+
+## SMB users explain the transfer themselves
+
+Because the transaction arrives as `OTHER` rather than `Xfer`, FreeAgent doesn't suggest a transfer when your SMB user explains it.
+
+They can still explain it as a transfer exactly as they do now, using the **Transfer to Another Account** option. They select it themselves instead of FreeAgent proposing it.

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -22,7 +22,7 @@ FreeAgent takes the direction from the `transactionType` instead, and overrides 
 | ------------------ | ---------------------------------------------------------------------------------------- |
 | Always money out   | `Debit`, `Fee`, `SerChg`, `Xfer`, `Check`, `Payment`, `Cash`, `DirectDebit`, `RepeatPmt` |
 | Always money in    | `Credit`, `Div`, `Dep`, `DirectDep`                                                      |
-| Uses the sign      | `INT`, `ATM`, `POS`, `OTHER`                                                             |
+| Uses the sign      | `Int`, `Atm`, `Pos`, `Other`, `Unknown`                                                  |
 
 So for a transaction sent as `amount: 1.60` with `transactionType: Xfer`, FreeAgent records £1.60 out, while integrations that use the sign, such as Xero and QuickBooks Online, record £1.60 in.
 
@@ -30,7 +30,7 @@ So for a transaction sent as `amount: 1.60` with `transactionType: Xfer`, FreeAg
 
 To keep the direction consistent with the `amount` you send, Codat writes a positive `Xfer` transaction to FreeAgent as `OTHER`. FreeAgent uses the sign for `OTHER` in both directions, so the transaction is recorded as money in, matching the sign of the `amount`.
 
-All other transactions are written to FreeAgent with the `transactionType` you supplied, unchanged. A negative `Xfer` isn't converted, because the type and the sign already agree.
+A negative `Xfer` isn't converted, because the type and the sign already agree. Codat converts no other type, but it does rename `SerChg` to FreeAgent's `SRVCHG` and writes `Unknown` as `OTHER`, neither of which changes the direction.
 
 :::caution Other conflicting types aren't converted
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -6,8 +6,6 @@ description: "Learn how to write your SMB users' bank transactions via our FreeA
 
 When an SMB user has set up a bank feed connection, you can write bank transactions for source bank accounts to FreeAgent. Write them using the [Create bank transactions](/bank-feeds-api#/operations/create-bank-transactions) endpoint, as described in [Write transactions](/bank-feeds/pushing-transactions).
 
-This article explains how FreeAgent decides whether a transfer is money in or money out, because it differs from other bank feeds integrations.
-
 ## Prerequisites
 
 - Your SMB user has an authorized FreeAgent connection and has [established a bank feed](/bank-feeds/mapping/overview).

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -1,0 +1,53 @@
+---
+title: "Write bank transactions to FreeAgent"
+sidebar_label: Write bank transactions
+description: "Learn how to write your SMB users' bank transactions via our FreeAgent Bank Feeds integration"
+---
+
+When an SMB user has set up a bank feed connection, you can write bank transactions for source bank accounts to FreeAgent. Write them using the [Create bank transactions](/bank-feeds-api#/operations/create-bank-transactions) endpoint, as described in [Write transactions](/bank-feeds/pushing-transactions).
+
+This article explains how FreeAgent decides whether a transaction is money in or money out, because it differs from other bank feeds integrations.
+
+## Prerequisites
+
+- Your SMB user has an authorized FreeAgent connection and has [established a bank feed](/bank-feeds/mapping/overview).
+
+## Transaction direction comes from the type
+
+In Codat's bank transactions schema, the sign of the `amount` determines the direction of a transaction: positive is money in, negative is money out. The `transactionType` describes the kind of transaction.
+
+FreeAgent takes the direction from the `transactionType` instead, and overrides the sign of the `amount` for most types.
+
+| FreeAgent behavior | Transaction types                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| Always money out   | `Debit`, `Fee`, `SerChg`, `Xfer`, `Check`, `Payment`, `Cash`, `DirectDebit`, `RepeatPmt` |
+| Always money in    | `Credit`, `Div`, `Dep`, `DirectDep`                                                      |
+| Uses the sign      | `INT`, `ATM`, `POS`, `OTHER`                                                             |
+
+So a transaction sent as `amount: 1.60` with `transactionType: Xfer` is recorded in FreeAgent as £1.60 out, while the same transaction is recorded as £1.60 in by integrations that use the sign, such as Xero and QuickBooks Online.
+
+## Codat converts a positive transfer
+
+To keep the direction consistent with the `amount` you send, Codat writes a positive `Xfer` transaction to FreeAgent as `OTHER`. FreeAgent uses the sign for `OTHER` in both directions, so the transaction is recorded as money in, matching the sign of the `amount`.
+
+All other transactions are written to FreeAgent with the `transactionType` you supplied, unchanged. A negative `Xfer` is not converted, because the type and the sign already agree.
+
+:::caution Other conflicting types are not converted
+
+Codat only converts `Xfer`. If you send a positive amount with any other type from the "Always money out" row above, FreeAgent records it as money out. Send those transactions with a type that matches the direction you want, or use `OTHER`.
+
+:::
+
+## The type appears in the description
+
+FreeAgent includes the transaction type in the description that the SMB user sees against the bank transaction. A transaction sent as `Xfer` reads as `//XFER/`, followed by the amount:
+
+```text
+your-transaction-description//XFER/£1.60
+```
+
+Because a positive `Xfer` is written as `OTHER`, the SMB user sees `//OTHER/` instead:
+
+```text
+your-transaction-description//OTHER/£1.60
+```

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions.md
@@ -24,17 +24,17 @@ FreeAgent takes the direction from the `transactionType` instead, and overrides 
 | Always money in    | `Credit`, `Div`, `Dep`, `DirectDep`                                                      |
 | Uses the sign      | `INT`, `ATM`, `POS`, `OTHER`                                                             |
 
-So a transaction sent as `amount: 1.60` with `transactionType: Xfer` is recorded in FreeAgent as £1.60 out, while the same transaction is recorded as £1.60 in by integrations that use the sign, such as Xero and QuickBooks Online.
+So for a transaction sent as `amount: 1.60` with `transactionType: Xfer`, FreeAgent records £1.60 out, while integrations that use the sign, such as Xero and QuickBooks Online, record £1.60 in.
 
 ## Codat converts a positive transfer
 
 To keep the direction consistent with the `amount` you send, Codat writes a positive `Xfer` transaction to FreeAgent as `OTHER`. FreeAgent uses the sign for `OTHER` in both directions, so the transaction is recorded as money in, matching the sign of the `amount`.
 
-All other transactions are written to FreeAgent with the `transactionType` you supplied, unchanged. A negative `Xfer` is not converted, because the type and the sign already agree.
+All other transactions are written to FreeAgent with the `transactionType` you supplied, unchanged. A negative `Xfer` isn't converted, because the type and the sign already agree.
 
-:::caution Other conflicting types are not converted
+:::caution Other conflicting types aren't converted
 
-Codat only converts `Xfer`. If you send a positive amount with any other type from the "Always money out" row above, FreeAgent records it as money out. Send those transactions with a type that matches the direction you want, or use `OTHER`.
+Codat only converts `Xfer`. If you send a positive amount with any other type in the **Always money out** group, FreeAgent records it as money out. Send those transactions with a type that matches the direction you want, or use `OTHER`.
 
 :::
 

--- a/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds.md
+++ b/docs/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds.md
@@ -1,0 +1,27 @@
+---
+title: "FreeAgent Bank Feeds"
+displayed_sidebar: integrationsBankFeeds
+description: "Learn about our FreeAgent Bank Feeds integration"
+---
+
+Our FreeAgent Bank Feeds integration allows you to set up a bank feed from a bank account in your application (the source bank account) to an account within FreeAgent (the target bank account). After a feed connection is established, you can write bank transactions from the source account to the target account.
+
+Bank feeds functionality is part of our existing [FreeAgent accounting integration](/integrations/accounting/freeagent/accounting-freeagent).
+
+## Supported data types and operations
+
+Bank feeds are represented as streams of [Bank account transactions](/bank-feeds-api#/schemas/BankTransactions) written to Codat in chronological order. Target bank accounts are represented as [Bank feed accounts](/bank-feeds-api#/schemas/BankFeedAccount).
+
+## How it works
+
+1. [Create a company and a data connection](/bank-feeds/create-account) using the `fbrh` platform key.
+
+2. Your SMB users authorize the connection with FreeAgent using our [Link auth flow](/auth-flow/overview).
+
+3. Your SMB users create account mappings and feed connections. See [Establish a bank feed](/bank-feeds/mapping/overview).
+
+4. Using the [Create bank transactions](/bank-feeds-api#/operations/create-bank-transactions) endpoint, you write bank transactions to Codat for authenticated users. See [Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions).
+
+## Read next
+
+[Write bank transactions to FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions)

--- a/docs/integrations/bank-feeds/overview.md
+++ b/docs/integrations/bank-feeds/overview.md
@@ -18,7 +18,7 @@ Read more about our [Bank Feeds](/bank-feeds/overview) solution.
 - [Xero](/integrations/bank-feeds/xero-bank-feeds/)
 - [NetSuite](/integrations/bank-feeds/netsuite-bank-feeds/netsuite-bank-feeds-setup)
 - [Exact Online (NL)](/integrations/accounting/exact-online/accounting-exact-online)
-- [FreeAgent](/integrations/accounting/freeagent/accounting-freeagent)
+- [FreeAgent](/integrations/bank-feeds/freeagent-bank-feeds/)
 
 ## Relevant solutions
 

--- a/sidebars/bank-feeds.js
+++ b/sidebars/bank-feeds.js
@@ -82,7 +82,7 @@ module.exports = [
   },
   {
     type: "link",
-    href: "/integrations/accounting/freeagent/accounting-freeagent",
+    href: "/integrations/bank-feeds/freeagent-bank-feeds",
     label: "FreeAgent",
   },
   {

--- a/sidebars/integrations-bank-feeds.js
+++ b/sidebars/integrations-bank-feeds.js
@@ -72,8 +72,16 @@ module.exports = [
     label: "Exact Online (NL)",
   },
   {
-    type: "link",
-    href: "/integrations/accounting/freeagent/accounting-freeagent",
+    type: "category",
     label: "FreeAgent",
+    collapsed: true,
+    items: [
+      {
+        type: "doc",
+        label: "Overview",
+        id: "integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds",
+      },
+      "integrations/bank-feeds/freeagent-bank-feeds/freeagent-bank-feeds-push-bank-transactions",
+    ],
   },
 ];


### PR DESCRIPTION
# Description

FreeAgent takes transaction direction from `transactionType`, not the sign of `amount`, unlike Xero and QuickBooks Online. Codat now sends a positive `Xfer` as `OTHER` so the sign is honored, and FreeAgent shows the type in the description the SMB sees.

Two separable commits:

1. One sentence on the cross-platform **Write transactions** page, next to the existing sign rule.
2. A new FreeAgent bank feeds section (Overview + Write bank transactions) plus nav entries. FreeAgent previously had no bank feeds pages and was linked to the generic accounting page.

## Type of change

- [x] New document(s)/updating existing
