### PR TITLE
EXP-2124 Use org secret ADO_NPM_FEED_TOKEN for codat-npm feed auth

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           {
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
-            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${ADO_NPM_FEED_TOKEN}"
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
           } >> ~/.npmrc
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ADO_NPM_FEED_TOKEN: ${{ secrets.ADO_NPM_FEED_TOKEN }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/check-markdown-lint.yml
+++ b/.github/workflows/check-markdown-lint.yml
@@ -34,11 +34,11 @@ jobs:
         run: |
           {
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
-            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${ADO_NPM_FEED_TOKEN}"
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
           } >> ~/.npmrc
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ADO_NPM_FEED_TOKEN: ${{ secrets.ADO_NPM_FEED_TOKEN }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -23,11 +23,11 @@ jobs:
         run: |
           {
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
-            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${ADO_NPM_FEED_TOKEN}"
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
           } >> ~/.npmrc
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ADO_NPM_FEED_TOKEN: ${{ secrets.ADO_NPM_FEED_TOKEN }}
 
       - name: Install dependencies
         run: npm install -g cspell

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,11 +32,11 @@ jobs:
         run: |
           {
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
-            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${NPM_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${ADO_NPM_FEED_TOKEN}"
             echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
           } >> ~/.npmrc
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ADO_NPM_FEED_TOKEN: ${{ secrets.ADO_NPM_FEED_TOKEN }}
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why

CI here authenticates to the Azure DevOps `codat-npm` feed using the repo-level `NPM_TOKEN` secret, which was backed by a 7-day PAT that expired on 3 Aug — every workflow running `npm ci` now fails with `E401`.

The `NPM_TOKEN` name is also overloaded across the org: `client-sdk-typescript` uses it to mean an npmjs.com publish token. To standardise, the ADO feed credential moves to an explicitly named **org-level** secret, `ADO_NPM_FEED_TOKEN`, shared with the repos that consume the feed (this repo and its sibling).

## What

Renames every `secrets.NPM_TOKEN` reference (and the matching shell env var) to `ADO_NPM_FEED_TOKEN` in the workflows that inject feed credentials into `~/.npmrc`. No behaviour change otherwise.

## Merge order

⚠️ Do not merge until the `ADO_NPM_FEED_TOKEN` org secret exists with repository access including this repo (all consuming repos are public, so visibility must be "selected" or "all" — not "private repositories"). Checks on this PR will stay red until then. After merging, delete the repo-level `NPM_TOKEN` secret.

Tracked in [EXP-2124](https://codatdocs.atlassian.net/browse/EXP-2124). Sibling PR: see ticket comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-2124]: https://codatdocs.atlassian.net/browse/EXP-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ