### PR TITLE
EXP-2127: Add per-PR preview deployments via GitHub Pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ ZENDESK_KEY=<zendesk key>
 GTM_ID=<google tag manager id>
 
 BRANCH=optional (sets the edit path)
+BASE_URL=optional (subpath the site is served from, no trailing slash; used by PR previews)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,9 @@ name: PR build
 
 on:
   pull_request:
+    # `closed` is included so the preview deployment is torn down when the PR
+    # closes; the build/link-check job skips that event
+    types: [opened, reopened, synchronize, closed]
   workflow_dispatch: # Allows manual triggering from the GitHub UI
 
 permissions:
@@ -11,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -116,3 +120,60 @@ jobs:
             if (filtered.length > 0) {
               core.setFailed("There are broken links in the documentation.");
             }
+
+  # Deploys the built site to GitHub Pages under pr-preview/pr-<number>/ and
+  # posts a sticky comment on the PR with the preview URL; the preview is
+  # removed when the PR closes. Builds separately from the job above because
+  # the preview needs a different baseUrl than the link check. Fork PRs are
+  # skipped: they get neither secrets nor a writable GITHUB_TOKEN.
+  deploy-preview:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Concurrent runs for the same PR would race on pushing to gh-pages
+    concurrency: pr-preview-${{ github.ref }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Images are Git LFS-tracked; skip fetching them on teardown, where
+          # the checkout is only needed so the action can push to gh-pages
+          lfs: ${{ github.event.action != 'closed' }}
+
+      - uses: actions/setup-node@v6
+        if: github.event.action != 'closed'
+        with:
+          node-version: 24
+          cache: npm
+
+      # The ADO registry requires auth even to install; the repo .npmrc is
+      # credential-less so creds go into ~/.npmrc here
+      - name: Authenticate to codat-npm feed
+        if: github.event.action != 'closed'
+        run: |
+          {
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:username=codat"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:_password=${ADO_NPM_FEED_TOKEN}"
+            echo "//pkgs.dev.azure.com/codat/Codat/_packaging/codat-npm/npm/registry/:email=npm-requires-email@example.com"
+          } >> ~/.npmrc
+        env:
+          ADO_NPM_FEED_TOKEN: ${{ secrets.ADO_NPM_FEED_TOKEN }}
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Build site for preview
+        if: github.event.action != 'closed'
+        run: npm run build
+        env:
+          GTM_ID: ${{ vars.GTM_ID }}
+          # GitHub Pages serves the preview from a subpath (no trailing slash)
+          BASE_URL: /codat-docs/pr-preview/pr-${{ github.event.number }}
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,7 @@ import navbar from "./nav.config";
 import redirects from "./redirects.config";
 
 import { generateAPISitemaps } from "./src/utils/oas-sitemap.js";
+import rehypeImageBaseUrl from "./src/utils/rehype-image-base-url.js";
 
 // PR preview deploys serve the site from a subpath on GitHub Pages, so the
 // preview workflow overrides this. No trailing slash — baseUrl appends one.
@@ -131,6 +132,7 @@ const config = {
           routeBasePath: "/",
           sidebarPath: "./sidebars.js",
           editUrl: `https://github.com/codatio/codat-docs/edit/${process.env?.BRANCH || "main"}/`,
+          rehypePlugins: [[rehypeImageBaseUrl, { baseUrl: `${BASE_URL}/` }]],
           exclude: ["README.md"],
           lastVersion: "current",
           versions: {
@@ -142,6 +144,7 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          rehypePlugins: [[rehypeImageBaseUrl, { baseUrl: `${BASE_URL}/` }]],
           blogTitle: "Codat updates",
           blogDescription: "Engineering and product updates from Codat.",
           postsPerPage: 10,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -81,7 +81,9 @@ import redirects from "./redirects.config";
 
 import { generateAPISitemaps } from "./src/utils/oas-sitemap.js";
 
-const BASE_URL = "";
+// PR preview deploys serve the site from a subpath on GitHub Pages, so the
+// preview workflow overrides this. No trailing slash — baseUrl appends one.
+const BASE_URL = process.env.BASE_URL ?? "";
 
 require("dotenv").config();
 

--- a/src/components/Api/index.tsx
+++ b/src/components/Api/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, Suspense } from "react";
 import { Helmet } from "react-helmet";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 import Layout from "@theme/Layout";
 import Navbar from "@theme/Navbar";
@@ -21,6 +22,9 @@ const Api = ({
   socialBanner = "https://docs.codat.io/img/meta/codat-bg.png",
 }) => {
   const [menuOpen, setMenuOpen] = useState(false);
+  // The OAS specs live in static/, so the fetch URL must respect baseUrl for
+  // deploys served from a subpath (e.g. PR previews)
+  const specUrl = useBaseUrl(url);
 
   return (
     <Layout title={title}>
@@ -48,7 +52,7 @@ const Api = ({
           <BrowserOnly>
             {() => (
               <Suspense fallback={Fallback}>
-                <LazyStoplight apiDescriptionUrl={url} />
+                <LazyStoplight apiDescriptionUrl={specUrl} />
               </Suspense>
             )}
           </BrowserOnly>

--- a/src/components/Cards/index.js
+++ b/src/components/Cards/index.js
@@ -1,10 +1,20 @@
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
+
+// Callers pass absolute image/link paths (e.g. /img/...), which bypass
+// baseUrl and break deploys served from a subpath (e.g. PR previews);
+// external URLs pass through withBaseUrl untouched
 const Card = (props) => {
   const { image, icon: Icon, title, children, className } = props;
+  const { withBaseUrl } = useBaseUrlUtils();
 
   return (
     <li className={`card ${className}`}>
       <div className="header">
-        {Icon ? <Icon /> : <img src={image} className="mini-icon" />}
+        {Icon ? (
+          <Icon />
+        ) : (
+          <img src={withBaseUrl(image)} className="mini-icon" />
+        )}
 
         <h3>{title}</h3>
       </div>
@@ -16,11 +26,12 @@ const Card = (props) => {
 
 const CardTwo = (props) => {
   const { image, title, link, linkText, children, className } = props;
+  const { withBaseUrl } = useBaseUrlUtils();
 
   return (
     <li className={`card two ${className}`}>
       <div className="header">
-        <img src={image} className="mini-icon" />
+        <img src={withBaseUrl(image)} className="mini-icon" />
 
         <h3>{title}</h3>
       </div>
@@ -28,7 +39,7 @@ const CardTwo = (props) => {
       {children}
 
       <p>
-        <a href={link}>{linkText} →</a>
+        <a href={withBaseUrl(link)}>{linkText} →</a>
       </p>
     </li>
   );
@@ -36,20 +47,21 @@ const CardTwo = (props) => {
 
 const MiniCard = (props) => {
   const { image, title, subtitle, link, children, className } = props;
+  const { withBaseUrl } = useBaseUrlUtils();
 
   return (
     <li className={`card mini ${className}`}>
       <div className="card-row">
         <div className="header">
-          <a href={link}>
-            <img src={image} className="icon usecase" />
+          <a href={withBaseUrl(link)}>
+            <img src={withBaseUrl(image)} className="icon usecase" />
           </a>
         </div>
 
         <div className="content">
           <h4>{title}</h4>
           <p>
-            <a href={link}>{subtitle} →</a>
+            <a href={withBaseUrl(link)}>{subtitle} →</a>
           </p>
         </div>
       </div>

--- a/src/components/ClientLibraries/index.tsx
+++ b/src/components/ClientLibraries/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 
 const repoBaseUrl = "https://github.com/codatio/client-sdk-";
 const repoProductTMP = "/tree/main/bank-feeds";
@@ -93,6 +94,9 @@ const getShieldUrl = (productName, language) => {
 
 const ClientLibraries = ({ productName }) => {
   const productUrl = !productName ? "" : "/tree/main/" + productName;
+  // The language icons are absolute /img/ paths, which bypass baseUrl and
+  // break deploys served from a subpath (e.g. PR previews)
+  const { withBaseUrl } = useBaseUrlUtils();
   return (
     <ul className="card-container mini">
       {languages.map((language, i) => {
@@ -104,7 +108,10 @@ const ClientLibraries = ({ productName }) => {
                   href={repoBaseUrl + language.name + productUrl}
                   target="_blank"
                 >
-                  <img src={language.icon} className="icon usecase" />
+                  <img
+                    src={withBaseUrl(language.icon)}
+                    className="icon usecase"
+                  />
                 </a>
               </div>
 

--- a/src/components/Clients/index.js
+++ b/src/components/Clients/index.js
@@ -1,14 +1,18 @@
 import React from "react";
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 
 import styles from "./styles.module.scss";
 
 const Client = (props) => {
   const { path, name, scale } = props;
+  // Callers pass absolute /img/ paths, which bypass baseUrl and break
+  // deploys served from a subpath (e.g. PR previews)
+  const { withBaseUrl } = useBaseUrlUtils();
 
   return (
     <div className={styles.client}>
       <img
-        src={path}
+        src={withBaseUrl(path)}
         alt={`${name} logo`}
         style={
           scale

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import { useColorMode } from "@docusaurus/theme-common";
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 
 import { ModalController } from "../Modal";
 
@@ -35,7 +36,12 @@ const PageHeader = ({
   videoText,
 }) => {
   const { colorMode } = useColorMode();
-  const resolvedIcon = iconDark && colorMode === "dark" ? iconDark : icon;
+  // icon/img arrive as absolute paths from frontmatter (banner_image etc.),
+  // which bypass baseUrl and break deploys served from a subpath
+  const { withBaseUrl } = useBaseUrlUtils();
+  const resolvedIcon = withBaseUrl(
+    iconDark && colorMode === "dark" ? iconDark : icon,
+  );
 
   return (
     <div className={clsx(styles.wrapper, className)}>
@@ -62,7 +68,7 @@ const PageHeader = ({
         {videoUrl && <BannerVideo text={videoText} url={videoUrl} />}
       </div>
 
-      {img && <img src={img} className={styles.heroImg} alt="" />}
+      {img && <img src={withBaseUrl(img)} className={styles.heroImg} alt="" />}
     </div>
   );
 };

--- a/src/components/Products/index.js
+++ b/src/components/Products/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useColorMode } from "@docusaurus/theme-common";
+import { useBaseUrlUtils } from "@docusaurus/useBaseUrl";
 
 const other = [
   {
@@ -104,6 +105,9 @@ const allProducts = [
 
 const Products = ({ mini, products, verbose }) => {
   const { colorMode } = useColorMode();
+  // The logo/link paths above are absolute, which bypasses baseUrl and
+  // breaks deploys served from a subpath (e.g. PR previews)
+  const { withBaseUrl } = useBaseUrlUtils();
   const validProducts = !products
     ? allProducts
     : products
@@ -130,15 +134,15 @@ const Products = ({ mini, products, verbose }) => {
               <div className="card-row">
                 <div className="header">
                   <a
-                    href={product.link}
+                    href={withBaseUrl(product.link)}
                     className={`icon-wrapper product animated ${product.slug}`}
                   >
                     <img
-                      src={
+                      src={withBaseUrl(
                         colorMode === "dark" && product.logoDark
                           ? product.logoDark
-                          : product.logo
-                      }
+                          : product.logo,
+                      )}
                       className="icon product"
                     />
                   </a>
@@ -147,7 +151,7 @@ const Products = ({ mini, products, verbose }) => {
                 <div className="content">
                   <h4>{product.name}</h4>
                   <p>
-                    <a href={product.link}>Explore solution →</a>
+                    <a href={withBaseUrl(product.link)}>Explore solution →</a>
                   </p>
                 </div>
               </div>
@@ -167,15 +171,15 @@ const Products = ({ mini, products, verbose }) => {
           <li key={i} className="card">
             <div className="header">
               <a
-                href={product.link}
+                href={withBaseUrl(product.link)}
                 className={`icon-wrapper product animated ${product.slug}`}
               >
                 <img
-                  src={
+                  src={withBaseUrl(
                     colorMode === "dark" && product.logoDark
                       ? product.logoDark
-                      : product.logo
-                  }
+                      : product.logo,
+                  )}
                   className="icon product"
                 />
               </a>
@@ -183,7 +187,7 @@ const Products = ({ mini, products, verbose }) => {
             <h3>{product.name}</h3>
             <p>{product.description}</p>
             <p>
-              <a href={product.link}>{product.linkText}</a>
+              <a href={withBaseUrl(product.link)}>{product.linkText}</a>
             </p>
           </li>
         );

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "@docusaurus/Link";
 import GearFinanceDownIcon from "@components/GearFinanceDownIcon";
 import FeatureBullet from "@components/FeatureBullet";
 import Layout from "@theme/Layout";
@@ -24,7 +25,7 @@ const RaiseSupportTicket = () => {
             </div>
             <p>
               Raise a technical issue with our support team{" "}
-              <a href="/raise-support-ticket">here</a>.
+              <Link to="/raise-support-ticket">here</Link>.
             </p>
           </li>
           <li className="card">

--- a/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/src/theme/BlogSidebar/Desktop/index.tsx
@@ -59,9 +59,9 @@ export default function BlogSidebarDesktop({ sidebar }: Props): JSX.Element {
               ))
             : "No deprecations"}
         </ul>
-        <a href="/updates/tags/deprecation" className={styles.sidebarItemList}>
+        <Link to="/updates/tags/deprecation" className={styles.sidebarItemList}>
           See all...
-        </a>
+        </Link>
 
         <br />
         <hr />

--- a/src/theme/MDXComponents/Img/index.js
+++ b/src/theme/MDXComponents/Img/index.js
@@ -1,16 +1,22 @@
 import React from "react";
 import clsx from "clsx";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import styles from "./styles.module.css";
 function transformImgClassName(className) {
   return clsx(className, styles.img);
 }
 export default function MDXImg(props) {
+  // Raw <img src="/img/..."> in MDX bypasses baseUrl, breaking any deploy
+  // served from a subpath (e.g. PR previews); bundled/external srcs pass
+  // through useBaseUrl untouched
+  const src = useBaseUrl(props.src);
   return (
     // eslint-disable-next-line jsx-a11y/alt-text
     <img
       decoding="async"
       loading="lazy"
       {...props}
+      src={src}
       className={transformImgClassName(props.className)}
     />
   );

--- a/src/utils/rehype-image-base-url.js
+++ b/src/utils/rehype-image-base-url.js
@@ -1,0 +1,40 @@
+// Literal <img> JSX written inside Markdown/MDX content bypasses the
+// MDXComponents mapping (and with it useBaseUrl), so absolute src paths
+// break when the site is served from a subpath (e.g. PR previews, where
+// baseUrl is /codat-docs/pr-preview/pr-<n>/). Rewrites those srcs at
+// compile time instead; a no-op for production builds, where baseUrl is "/".
+const rehypeImageBaseUrl = ({ baseUrl }) => {
+  const prefix = (src) =>
+    typeof src === "string" && src.startsWith("/") && !src.startsWith("//")
+      ? baseUrl + src.slice(1)
+      : src;
+
+  const visit = (node) => {
+    if (node.type === "element" && node.tagName === "img" && node.properties) {
+      node.properties.src = prefix(node.properties.src);
+    }
+
+    if (
+      (node.type === "mdxJsxFlowElement" ||
+        node.type === "mdxJsxTextElement") &&
+      node.name === "img"
+    ) {
+      for (const attr of node.attributes ?? []) {
+        if (attr.type === "mdxJsxAttribute" && attr.name === "src") {
+          attr.value = prefix(attr.value);
+        }
+      }
+    }
+
+    (node.children ?? []).forEach(visit);
+  };
+
+  return (tree) => {
+    if (!baseUrl || baseUrl === "/") {
+      return;
+    }
+    visit(tree);
+  };
+};
+
+export default rehypeImageBaseUrl;


### PR DESCRIPTION
Adds per-PR preview deployments so reviewers can browse the rendered site before it merges. Jira: [EXP-2127](https://codatdocs.atlassian.net/browse/EXP-2127) (under [EXP-1595](https://codatdocs.atlassian.net/browse/EXP-1595)).

## What this does

- New `deploy-preview` job in the PR workflow: builds the site with `BASE_URL=/codat-docs/pr-preview/pr-<number>` and publishes it to the `gh-pages` branch via [`rossjrw/pr-preview-action`](https://github.com/rossjrw/pr-preview-action), which posts a sticky comment on the PR with the preview URL and updates it on every push.
- The preview is torn down automatically when the PR closes (the workflow now also triggers on `closed`; the build/link-check job skips that event).
- `BASE_URL` in `docusaurus.config.js` is now env-driven. Production/integration builds are unaffected — with the env var unset it resolves to the current `baseUrl` of `/`.
- Fork PRs skip the preview job (no secrets, read-only `GITHUB_TOKEN`).

## Setup status

- ✅ `gh-pages` branch initialised (root `.nojekyll` + placeholder index).
- ✅ GitHub Pages enabled on the repo, serving `gh-pages` at https://codatio.github.io/codat-docs/ (required a one-off org-policy change to allow public Pages creation).
- This PR should demonstrate the feature on itself — look for the preview sticky comment below.

## Notes / tradeoffs

- Previews are public to anyone with the URL (same exposure as any preview host for a public repo).
- The `gh-pages` branch accumulates history (image-heavy build output); an occasional force-reset keeps it in check.
- EXP-1595's pattern of record has PR previews on Azure Static Web Apps long-term; this is a zero-infra interim and is easy to unwind (delete the job + `gh-pages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[EXP-2127]: https://codatdocs.atlassian.net/browse/EXP-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXP-1595]: https://codatdocs.atlassian.net/browse/EXP-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ