### PR TITLE
Wait for Pages deployment before posting preview link

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,6 +135,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # wait-for-pages-deployment polls the Pages builds API
+      pages: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -177,3 +179,6 @@ jobs:
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./build
+          # Hold the sticky comment until the Pages deployment is live;
+          # otherwise the preview link 404s for the first minute or so
+          wait-for-pages-deployment: true


### PR DESCRIPTION
## What

Adds `wait-for-pages-deployment: true` to the `rossjrw/pr-preview-action` step, plus the `pages: read` permission the wait needs to poll the Pages builds API (the job's explicit `permissions` block otherwise zeroes it).

## Why

The preview sticky comment currently lands as soon as the build is pushed to `gh-pages`, ~30–60s before the GitHub Pages deployment actually finishes — so the link 404s if you click it straight away (e.g. https://github.com/codatio/codat-docs/pull/1850#issuecomment-5192595323). With this input the action tracks the Pages build and only posts the comment once the URL is live.

Same change is going into the other two repos that share this preview pattern (codat-docs / engineering-blog / help).

Trade-off: the `deploy-preview` job runs ~30–60s longer while it waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
