### PR TITLE
docs(lending): add CBS report retention policy to Supported Outputs

### DIFF
--- a/docs/integrations/banking/plaid/switching-between-plaid-environments.md
+++ b/docs/integrations/banking/plaid/switching-between-plaid-environments.md
@@ -42,7 +42,7 @@ The following example shows how to switch Codat to point to Plaid Development in
 
 Get your existing environment credentials.
 
-1. Open the <a href="https://api.codat.io/swagger/ui/index.html#/Integrations/Integrations_GetCredentials" target="_blank">`GET /integrations/credentials/{platformKey}`</a> endpoint.
+1. Open the <a href="https://api.codat.io/swagger/index.html#/Integrations/get_integrations_credentials__platformKey_" target="_blank">`GET /integrations/credentials/{platformKey}`</a> endpoint.
 2. Replace `{platformKey}` with `plaid` and send your request to return your current credentials. Save the JSON, you'll need it later.
 
 ```json
@@ -60,7 +60,7 @@ Find the secret for Plaid's development environment.
 
 Update your environment credentials.
 
-1. Open the <a href="https://api.codat.io/swagger/ui/index#!/Integrations/Integrations_PutCredentials" target="_blank">  
+1. Open the <a href="https://api.codat.io/swagger/index.html#/Integrations/put_integrations_credentials__platformKey_" target="_blank">  
    `PUT /integrations/credentials/{platformKey}`</a> endpoint.
 2. Replace `{platformKey}` with `plaid` and send the following details:
    - The existing environment credentials you fetched earlier, replacing the original **clientSecret** with the secret for the development environment.

--- a/docs/lending/features/excel-download-overview.md
+++ b/docs/lending/features/excel-download-overview.md
@@ -216,6 +216,21 @@ You can also generate and download a report in an Excel format via the [Portal](
 
 You can also generate and download the **data export** report by clicking the **Export data** button on any of the Lending screens of the Portal.
 
+#### Report retention
+
+Lending reports are subject to two layers of retention:
+
+- **Time-based:** all reports are retained for approximately 90 days from generation, after which they are automatically removed.
+- **Count-based (categorized bank statements only):** only the most recent report is retained. When a new report is generated, the previous report is immediately deleted, even if it is still within the 90-day window.
+
+Because categorized bank statements are cumulative — each report contains all transactions from connected accounts to date — the latest report always includes all data from prior reports. We recommend fetching the most recent report using the [`/latest` endpoint](/lending-api#/operations/get-categorized-bank-statement) rather than storing and re-requesting a specific `reportId`.
+
+:::note 404 on older report IDs
+
+Requesting a superseded `reportId` via `GET /reports/{reportId}` returns a **404** response. This is expected — the report has been removed by the retention policy, not due to an error. Always use `/latest` to reliably retrieve the current report.
+
+:::
+
 ---
 
 ## Read next


### PR DESCRIPTION
Recreation of #1848 from an in-repo branch so CI secrets (npm feed token, Docker Hub PAT) are available — the original fork PR could not access them and all builds failed at install/login. All content authored by @hmansour-codat; commit authorship preserved.

---

Documents the two-layer retention behaviour for categorized bank statement reports:
- Time-based: ~90-day window for all report types
- Count-based (CBS only): only the latest report is retained; previous reports are removed when a new one is generated

Includes guidance to use /latest endpoint and explains expected 404 behaviour on superseded reportIds.

Refs: MED-814

🤖 Generated with [Claude Code](https://claude.com/claude-code)
