### PR TITLE
CONN-801: announce update bills/suppliers support for NetSuite, Sage Intacct, Zoho Books

### DIFF
--- a/blog/260810-update-bills-suppliers-more-platforms.md
+++ b/blog/260810-update-bills-suppliers-more-platforms.md
@@ -1,0 +1,24 @@
+---
+title: "Bill Pay: update bills and suppliers on more platforms"
+date: "2026-08-10"
+tags: ["Product", "Update", "Bill Pay"]
+authors: njackson
+---
+
+You can now update bills and suppliers through our Bill Pay solution for Oracle NetSuite, Sage Intacct, and Zoho Books.
+
+<!--truncate-->
+
+## What's new?
+
+We've extended the [Update bill](/sync-for-payables-v2-api#/operations/update-bill) and [Update supplier](/sync-for-payables-v2-api#/operations/update-supplier) endpoints of our [Bill Pay](/payables/overview) solution to three more integrations: Oracle NetSuite, Sage Intacct, and Zoho Books.
+
+Together with the existing FreeAgent, QuickBooks Online, and Xero support, your customers can now edit bills and suppliers across six accounting integrations, and we will automatically sync these changes to their accounting software, keeping the records accurate and up-to-date.
+
+## Who is this relevant for?
+
+This update is relevant for all clients using Codat's Bill Pay solution who want to give their customers a seamless bill and supplier management experience on NetSuite, Sage Intacct, or Zoho Books.
+
+## How to get started?
+
+You can start using the endpoints with the new integrations right now. Check out the [Update bill](/sync-for-payables-v2-api#/operations/update-bill) and [Update supplier](/sync-for-payables-v2-api#/operations/update-supplier) endpoints in our API reference, or explore Bill Pay's [Update bills](/payables/sync/update-bill) and [Update supplier](/payables/sync/suppliers#update-supplier) documentation for a full walkthrough.

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -195,3 +195,9 @@ rharrison:
   title: Senior Software Engineer
   url: https://github.com/Rob-Codat
   image_url: https://github.com/Rob-Codat.png
+
+njackson:
+  name: Nathan Jackson
+  title: Software Engineer
+  url: https://github.com/NathanJCodat
+  image_url: https://github.com/NathanJCodat.png


### PR DESCRIPTION
## What

Adds an update post to the [Codat updates](https://docs.codat.io/updates) feed announcing that the Bill Pay [Update bill](https://docs.codat.io/sync-for-payables-v2-api#/operations/update-bill) and [Update supplier](https://docs.codat.io/sync-for-payables-v2-api#/operations/update-supplier) endpoints now support Oracle NetSuite, Sage Intacct, and Zoho Books (shipped under the CONN-783 epic, documented in #1875).

- **`blog/260810-update-bills-suppliers-more-platforms.md`** — the post, following the structure of the original two announcements ([260219-update-bills-bill-pay](https://docs.codat.io/updates/260219-update-bills-bill-pay/), [260331-update-suppliers-bill-pay](https://docs.codat.io/updates/260331-update-suppliers-bill-pay/)), covering both endpoints in one post and linking to the API reference and the docs walkthroughs.
- **`blog/authors.yml`** — adds `njackson` (Nathan Jackson) as a blog author.

## Notes

- The post is dated 2026-08-10; happy to bump the date/filename to the merge date if preferred.
- cspell and prettier pass; verified rendered locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
