### PR TITLE
Product update: manage connections and reconnect companies in embedded Link

### DIFF
--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -1,0 +1,43 @@
+---
+title: "Manage connections and reconnect companies seamlessly with embedded Link"
+date: "2026-08-12"
+tags: ["Product", "Update", "Link"]
+hide_table_of_contents: true
+authors: avanjani
+---
+
+You can now offer your customers a first-class connection management experience in Link, making it easy for business users to view, disconnect, and reconnect their linked companies - and ensuring they reconnect the right one.
+
+<!--truncate-->
+
+## What's new?
+
+Previously, when a company's connection was lost - through token expiry, a disconnect, or user action - there was no dedicated way to reconnect it. Users had to go through the standard Link flow again, with no guarantee they'd reconnect the same accounting file or legal entity they originally linked. Connecting a different entity by mistake meant broken data continuity and confused downstream reporting.
+
+With the new manage connections experience, business users can:
+
+- See what they previously connected and relink it directly in Link.
+- Disconnect an existing connection when they need to revoke access.
+- Reconnect with confidence - when a user authenticates with their accounting software, Link validates that the company they're reconnecting matches the one originally connected.
+- Catch mistakes before they happen - if the identities don't match, the user sees a clear warning that they're about to connect a different company, with the option to confirm or go back and select the correct one.
+
+<!-- TODO: add screenshot - manage connections view -->
+
+<!-- TODO: add screenshot - company mismatch warning -->
+
+The reconnection experience is available for QuickBooks Online, Oracle NetSuite, and Sage Intacct connections via embedded Link.
+
+## Who is it relevant for?
+
+Any client whose customers connect accounting platforms through embedded Link - particularly banks and lenders that rely on continuous, uninterrupted data from the same company for insights, monitoring, and credit decisioning.
+
+## How to get started?
+
+The manage connections experience is available in the Link SDK. To set it up:
+
+1. **Enable the manage connections setting** in your Link configuration to let authenticated users view and manage their existing connections.
+2. **Get a company access token.** Authenticated features require an access token, retrieved server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
+3. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
+4. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+
+Reach out to your account manager or our support team if you'd like help getting set up.

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -24,29 +24,59 @@ With the new manage connections experience, business users can:
 <div
   style={{
     display: "flex",
-    gap: "1rem",
+    gap: "2rem",
     justifyContent: "center",
+    alignItems: "flex-start",
     flexWrap: "wrap",
+    margin: "1.5rem 0",
   }}
 >
-  <div style={{ textAlign: "center", flex: "1", minWidth: "280px" }}>
+  <figure style={{ margin: 0, textAlign: "center" }}>
     <img
       src="/img/updates/Relink-1.png"
       alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
+      style={{
+        height: "520px",
+        width: "auto",
+        maxWidth: "100%",
+        border: "1px solid var(--ifm-color-emphasis-200)",
+        borderRadius: "12px",
+        boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)",
+      }}
     />
-    <p>
-      <em>Reconnect a disconnected platform</em>
-    </p>
-  </div>
-  <div style={{ textAlign: "center", flex: "1", minWidth: "280px" }}>
+    <figcaption
+      style={{
+        marginTop: "0.75rem",
+        fontSize: "0.85rem",
+        color: "var(--ifm-color-emphasis-600)",
+      }}
+    >
+      Reconnect a disconnected platform
+    </figcaption>
+  </figure>
+  <figure style={{ margin: 0, textAlign: "center" }}>
     <img
       src="/img/updates/Relink-2.png"
       alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
+      style={{
+        height: "520px",
+        width: "auto",
+        maxWidth: "100%",
+        border: "1px solid var(--ifm-color-emphasis-200)",
+        borderRadius: "12px",
+        boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)",
+      }}
     />
-    <p>
-      <em>Company mismatch warning</em>
-    </p>
-  </div>
+    <figcaption
+      style={{
+        marginTop: "0.75rem",
+        fontSize: "0.85rem",
+        color: "var(--ifm-color-emphasis-600)",
+      }}
+    >
+      Company mismatch warning
+    </figcaption>
+  </figure>
 </div>
 
 The reconnection experience is available for QuickBooks Online, Oracle NetSuite, and Sage Intacct connections via embedded Link.

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -24,7 +24,7 @@ With the new manage connections experience, business users can:
 <div
   style={{
     display: "flex",
-    gap: "2rem",
+    gap: "1.5rem",
     justifyContent: "center",
     alignItems: "flex-start",
     flexWrap: "wrap",
@@ -36,7 +36,7 @@ With the new manage connections experience, business users can:
       src="/img/updates/Relink-1.png"
       alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
       style={{
-        height: "520px",
+        height: "460px",
         width: "auto",
         maxWidth: "100%",
         border: "1px solid var(--ifm-color-emphasis-200)",
@@ -59,7 +59,7 @@ With the new manage connections experience, business users can:
       src="/img/updates/Relink-2.png"
       alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
       style={{
-        height: "520px",
+        height: "460px",
         width: "auto",
         maxWidth: "100%",
         border: "1px solid var(--ifm-color-emphasis-200)",
@@ -75,6 +75,29 @@ With the new manage connections experience, business users can:
       }}
     >
       Mismatch warning when reconnecting
+    </figcaption>
+  </figure>
+  <figure style={{ margin: 0, textAlign: "center" }}>
+    <img
+      src="/img/updates/Disconnect.png"
+      alt="A connected Xero connection in Link showing connection details and a Disconnect button"
+      style={{
+        height: "460px",
+        width: "auto",
+        maxWidth: "100%",
+        border: "1px solid var(--ifm-color-emphasis-200)",
+        borderRadius: "12px",
+        boxShadow: "0 2px 8px rgba(0, 0, 0, 0.08)",
+      }}
+    />
+    <figcaption
+      style={{
+        marginTop: "0.75rem",
+        fontSize: "0.85rem",
+        color: "var(--ifm-color-emphasis-600)",
+      }}
+    >
+      Option to disconnect a connected platform
     </figcaption>
   </figure>
 </div>

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -31,7 +31,7 @@ With the new manage connections experience, business users can:
     margin: "1.5rem 0",
   }}
 >
-  <figure style={{ margin: 0, textAlign: "center" }}>
+  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
     <img
       src="/img/updates/Relink-1.png"
       alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
@@ -54,7 +54,7 @@ With the new manage connections experience, business users can:
       Reconnect a disconnected platform
     </figcaption>
   </figure>
-  <figure style={{ margin: 0, textAlign: "center" }}>
+  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
     <img
       src="/img/updates/Relink-2.png"
       alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
@@ -77,7 +77,7 @@ With the new manage connections experience, business users can:
       Mismatch warning when reconnecting
     </figcaption>
   </figure>
-  <figure style={{ margin: 0, textAlign: "center" }}>
+  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
     <img
       src="/img/updates/Disconnect.png"
       alt="A connected Xero connection in Link showing connection details and a Disconnect button"

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -24,7 +24,7 @@ With the new manage connections experience, business users can:
 <div
   style={{
     display: "flex",
-    gap: "1.5rem",
+    gap: "1rem",
     justifyContent: "center",
     alignItems: "flex-start",
     flexWrap: "wrap",
@@ -36,7 +36,7 @@ With the new manage connections experience, business users can:
       src="/img/updates/Relink-1.png"
       alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
       style={{
-        height: "460px",
+        height: "440px",
         width: "auto",
         maxWidth: "100%",
         border: "1px solid var(--ifm-color-emphasis-200)",
@@ -59,7 +59,7 @@ With the new manage connections experience, business users can:
       src="/img/updates/Relink-2.png"
       alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
       style={{
-        height: "460px",
+        height: "440px",
         width: "auto",
         maxWidth: "100%",
         border: "1px solid var(--ifm-color-emphasis-200)",
@@ -82,7 +82,7 @@ With the new manage connections experience, business users can:
       src="/img/updates/Disconnect.png"
       alt="A connected Xero connection in Link showing connection details and a Disconnect button"
       style={{
-        height: "460px",
+        height: "440px",
         width: "auto",
         maxWidth: "100%",
         border: "1px solid var(--ifm-color-emphasis-200)",

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -79,11 +79,13 @@ With the new manage connections experience, business users can:
   </figure>
 </div>
 
-The reconnection experience is available for QuickBooks Online, Oracle NetSuite, and Sage Intacct connections via embedded Link.
+The reconnection flow is available for all platforms. Validation against the previously connected company is currently available for QuickBooks Online, Oracle NetSuite, and Sage Intacct.
+
+Relinking is available in embedded Link, and in [Hosted Link](/auth-flow/authorize-hosted-link) for clients using [secure linking](/updates/250110-secure-linking) with one-time passwords (OTPs) enabled.
 
 ## Who is it relevant for?
 
-Any client whose customers connect accounting platforms through embedded Link - particularly banks and lenders that rely on continuous, uninterrupted data from the same company for insights, monitoring, and credit decisioning.
+Any client whose customers connect accounting platforms through Link - particularly banks and lenders that rely on continuous, uninterrupted data from the same company for insights, monitoring, and credit decisioning.
 
 ## How to get started?
 
@@ -92,8 +94,10 @@ The manage connections experience is available in the Link SDK. To set it up:
 1. **Enable the Manage connections setting** in the [Codat Portal](https://app.codat.io) under [Settings > Auth flow > Link](https://app.codat.io/settings/link-settings/onboarding) to let authenticated users view and manage their existing connections. You can also customize the title and subtitle shown on the manage connections screen.
 
    ![The Manage connections setting in the Codat Portal's Link settings, with a toggle and customizable title and subtitle](/img/updates/manageconnection.png "Manage connections setting in the Codat Portal")
-2. **Get a company access token.** Authenticated features require an access token, retrieved server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
-3. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
-4. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+2. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+3. **Get a company access token.** Authenticated features require an access token, retrieved server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
+4. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
+
+Using Hosted Link? Relinking is available there too when one-time passwords (OTPs) are enabled. We highly recommend setting this up - follow the instructions in our [secure linking](/updates/250110-secure-linking) update.
 
 Reach out to your account manager or our support team if you'd like help getting set up.

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -21,9 +21,9 @@ With the new manage connections experience, business users can:
 - Reconnect with confidence - when a user authenticates with their accounting software, Link validates that the company they're reconnecting matches the one originally connected.
 - Catch mistakes before they happen - if the identities don't match, the user sees a clear warning that they're about to connect a different company, with the option to confirm or go back and select the correct one.
 
-<!-- TODO: add screenshot - manage connections view -->
+![A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button](/img/updates/Relink-1.png "Reconnect a disconnected platform")
 
-<!-- TODO: add screenshot - company mismatch warning -->
+![A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel](/img/updates/Relink-2.png "Company mismatch warning")
 
 The reconnection experience is available for QuickBooks Online, Oracle NetSuite, and Sage Intacct connections via embedded Link.
 

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -89,7 +89,9 @@ Any client whose customers connect accounting platforms through embedded Link - 
 
 The manage connections experience is available in the Link SDK. To set it up:
 
-1. **Enable the manage connections setting** in your Link configuration to let authenticated users view and manage their existing connections.
+1. **Enable the Manage connections setting** in the [Codat Portal](https://app.codat.io) under [Settings > Auth flow > Link](https://app.codat.io/settings/link-settings/onboarding) to let authenticated users view and manage their existing connections. You can also customize the title and subtitle shown on the manage connections screen.
+
+   ![The Manage connections setting in the Codat Portal's Link settings, with a toggle and customizable title and subtitle](/img/updates/manageconnection.png "Manage connections setting in the Codat Portal")
 2. **Get a company access token.** Authenticated features require an access token, retrieved server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
 3. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
 4. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -21,9 +21,33 @@ With the new manage connections experience, business users can:
 - Reconnect with confidence - when a user authenticates with their accounting software, Link validates that the company they're reconnecting matches the one originally connected.
 - Catch mistakes before they happen - if the identities don't match, the user sees a clear warning that they're about to connect a different company, with the option to confirm or go back and select the correct one.
 
-![A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button](/img/updates/Relink-1.png "Reconnect a disconnected platform")
-
-![A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel](/img/updates/Relink-2.png "Company mismatch warning")
+<div
+  style={{
+    display: "flex",
+    gap: "1rem",
+    justifyContent: "center",
+    flexWrap: "wrap",
+  }}
+>
+  <div style={{ textAlign: "center", flex: "1", minWidth: "280px" }}>
+    <img
+      src="/img/updates/Relink-1.png"
+      alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
+    />
+    <p>
+      <em>Reconnect a disconnected platform</em>
+    </p>
+  </div>
+  <div style={{ textAlign: "center", flex: "1", minWidth: "280px" }}>
+    <img
+      src="/img/updates/Relink-2.png"
+      alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
+    />
+    <p>
+      <em>Company mismatch warning</em>
+    </p>
+  </div>
+</div>
 
 The reconnection experience is available for QuickBooks Online, Oracle NetSuite, and Sage Intacct connections via embedded Link.
 

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -74,7 +74,7 @@ With the new manage connections experience, business users can:
         color: "var(--ifm-color-emphasis-600)",
       }}
     >
-      Company mismatch warning
+      Mismatch warning when reconnecting
     </figcaption>
   </figure>
 </div>

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -31,7 +31,7 @@ With the new manage connections experience, business users can:
     margin: "1.5rem 0",
   }}
 >
-  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
+  <figure style={{ margin: 0, textAlign: "center" }}>
     <img
       src="/img/updates/Relink-1.png"
       alt="A disconnected Oracle NetSuite connection in Link showing connection details and a Reconnect button"
@@ -46,6 +46,8 @@ With the new manage connections experience, business users can:
     />
     <figcaption
       style={{
+        width: 0,
+        minWidth: "100%",
         marginTop: "0.75rem",
         fontSize: "0.85rem",
         color: "var(--ifm-color-emphasis-600)",
@@ -54,7 +56,7 @@ With the new manage connections experience, business users can:
       Reconnect a disconnected platform
     </figcaption>
   </figure>
-  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
+  <figure style={{ margin: 0, textAlign: "center" }}>
     <img
       src="/img/updates/Relink-2.png"
       alt="A warning in Link showing that the selected company does not match the previously connected company, with options to reselect or cancel"
@@ -69,6 +71,8 @@ With the new manage connections experience, business users can:
     />
     <figcaption
       style={{
+        width: 0,
+        minWidth: "100%",
         marginTop: "0.75rem",
         fontSize: "0.85rem",
         color: "var(--ifm-color-emphasis-600)",
@@ -77,7 +81,7 @@ With the new manage connections experience, business users can:
       Mismatch warning when reconnecting
     </figcaption>
   </figure>
-  <figure style={{ margin: 0, textAlign: "center", width: "min-content" }}>
+  <figure style={{ margin: 0, textAlign: "center" }}>
     <img
       src="/img/updates/Disconnect.png"
       alt="A connected Xero connection in Link showing connection details and a Disconnect button"
@@ -92,6 +96,8 @@ With the new manage connections experience, business users can:
     />
     <figcaption
       style={{
+        width: 0,
+        minWidth: "100%",
         marginTop: "0.75rem",
         fontSize: "0.85rem",
         color: "var(--ifm-color-emphasis-600)",

--- a/static/img/updates/Disconnect.png
+++ b/static/img/updates/Disconnect.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c75a74be5ec977413b34bf76271db7eae62473b593fb032cd247ec2332bc34d
+size 27189

--- a/static/img/updates/Relink-1.png
+++ b/static/img/updates/Relink-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c5fee97b6faf65facddd37560107146ee359d144c675de23d9858a926f25cbd
+size 44645

--- a/static/img/updates/Relink-2.png
+++ b/static/img/updates/Relink-2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c092a76214fcaa029cf0bee1830dde5934222a6c5f80a97759475934c7e521a
+size 77594

--- a/static/img/updates/manageconnection.png
+++ b/static/img/updates/manageconnection.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ff6c4996c1da2977e0234fc72c5e159b4cc7c30dd8f3b70999de5e621118f78
+size 25251


### PR DESCRIPTION
## Summary

New product update post for [docs.codat.io/updates](https://docs.codat.io/updates) announcing the Link manage connections / reconnection experience ([EXP-1630](https://codatdocs.atlassian.net/browse/EXP-1630)).

Covers:
- Viewing and relinking previously connected companies in embedded Link
- Disconnecting an existing connection
- Company identity validation on reconnect, with a mismatch warning
- Availability: QuickBooks Online, Oracle NetSuite, Sage Intacct
- Getting started: manage connections setting, company access token, `accessToken` prop, CORS settings

## Outstanding before publishing

- [ ] Screenshots to be added (placeholders marked with TODO comments in the post)
- [ ] Confirm whether view/disconnect works for all integrations or only the three ERPs listed for reconnection
- [ ] Confirm the manage connections setting is client-configurable vs enabled by Codat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EXP-1630]: https://codatdocs.atlassian.net/browse/EXP-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ