### PR TITLE
Update "How to get started" on the secure linking update

### DIFF
--- a/blog/250110-secure-linking.md
+++ b/blog/250110-secure-linking.md
@@ -30,7 +30,7 @@ All clients who want to have stricter rules around Link URLs sent to their custo
 
 ## How to get started?
 
-One-time Link URLs are self-serve. To set them up:
+To set up one-time Link URLs:
 
 1. **Enable the One-time Link URLs setting** in the [Codat Portal](https://app.codat.io) under **[Settings > Auth flow > Link > Onboarding](https://app.codat.io/settings/link-settings/onboarding)**.
 2. **Complete the additional steps for your Link flow**, as described below.

--- a/blog/250110-secure-linking.md
+++ b/blog/250110-secure-linking.md
@@ -47,8 +47,8 @@ If you are currently adding query parameters to Link URLs (for example, by appen
 
 The Link SDK uses an access token instead of an appended one-time password. To set this up:
 
-1. **Get a company access token.** Retrieve it server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
-2. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
-3. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+1. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+2. **Get a company access token.** Retrieve it server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
+3. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
 
 Reach out to your account manager or our support team if you'd like help getting set up.

--- a/blog/250110-secure-linking.md
+++ b/blog/250110-secure-linking.md
@@ -30,7 +30,10 @@ All clients who want to have stricter rules around Link URLs sent to their custo
 
 ## How to get started?
 
-Contact your Codat account manager with the request to enable one-time Link URLs. Depending on the type of the Link flow you are using, you also need to action the following:
+One-time Link URLs are self-serve. To set them up:
+
+1. **Enable the One-time Link URLs setting** in the [Codat Portal](https://app.codat.io) under **[Settings > Auth flow > Link > Onboarding](https://app.codat.io/settings/link-settings/onboarding)**.
+2. **Complete the additional steps for your Link flow**, as described below.
 
 #### If using Hosted Link
 
@@ -42,4 +45,10 @@ If you are currently adding query parameters to Link URLs (for example, by appen
 
 #### If using Link SDK
 
-To enforce the limited validity of Link URLs using the Link SDK, you need to retrieve an access token for your customer using the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint and pass it when initializing the SDK. This serves as an equivalent to a one-time password appended to a Link URL.
+The Link SDK uses an access token instead of an appended one-time password. To set this up:
+
+1. **Get a company access token.** Retrieve it server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
+2. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.
+3. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
+
+Reach out to your account manager or our support team if you'd like help getting set up.


### PR DESCRIPTION
Refreshes the **How to get started** section of [`updates/250110-secure-linking`](https://docs.codat.io/updates/250110-secure-linking/).

## Why

Two things were out of date:

- Enabling one-time Link URLs no longer requires contacting an account manager - there is a self-serve **One-time Link URLs** toggle in the Portal under **Settings > Auth flow > Link > Onboarding**.
- The Link SDK path was missing the CORS step. Without registering the domain via **Set CORS settings**, the access token cannot be used from the customer site.

## What changed

- Section restructured into numbered steps, matching the format used in the [manage connections / reconnect update](https://github.com/codatio/codat-docs/pull/1879).
- Step 1 points at the Portal toggle and its exact settings tab.
- The Link SDK subsection now spells out three steps in setup order: register the domain via Set CORS settings, get a company access token, then pass it via the `accessToken` prop. CORS comes first because it is a prerequisite for the token to work.
- Hosted Link and build-your-own caveats are unchanged.

## Out of scope

`docs/auth-flow/authorize-hosted-link.md` (lines 88 and 127) still says "contact your account manager" for the same feature. Worth a follow-up, but left alone here to keep this PR to the page that was asked about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)