### PR TITLE
Remove obsolete Hosted Link prerequisite from the secure linking update

### DIFF
--- a/blog/250110-secure-linking.md
+++ b/blog/250110-secure-linking.md
@@ -35,7 +35,7 @@ To set up one-time Link URLs:
 1. **Enable the One-time Link URLs setting** in the [Codat Portal](https://app.codat.io) under **[Settings > Auth flow > Link > Onboarding](https://app.codat.io/settings/link-settings/onboarding)**.
 2. **Complete the additional steps for your Link flow**, as described below.
 
-#### If using Hosted or build-your-own Link
+#### If using Hosted Link or your own custom-built Link UI
 
 If you are currently adding query parameters to Link URLs (for example, by appending `?link.showSandboxIntegrations=false`), confirm that your code can handle URLs that already contain query strings.
 

--- a/blog/250110-secure-linking.md
+++ b/blog/250110-secure-linking.md
@@ -35,10 +35,6 @@ To set up one-time Link URLs:
 1. **Enable the One-time Link URLs setting** in the [Codat Portal](https://app.codat.io) under **[Settings > Auth flow > Link > Onboarding](https://app.codat.io/settings/link-settings/onboarding)**.
 2. **Complete the additional steps for your Link flow**, as described below.
 
-#### If using Hosted Link
-
-As a prerequisite to enabling one-time Link URLs, you also need to enable the [new Hosted Link interface](/updates/250110-new-hosted-link-ui).
-
 #### If using Hosted or build-your-own Link
 
 If you are currently adding query parameters to Link URLs (for example, by appending `?link.showSandboxIntegrations=false`), confirm that your code can handle URLs that already contain query strings.

--- a/blog/260812-link-manage-connections-reconnect.md
+++ b/blog/260812-link-manage-connections-reconnect.md
@@ -123,6 +123,7 @@ The manage connections experience is available in the Link SDK. To set it up:
 1. **Enable the Manage connections setting** in the [Codat Portal](https://app.codat.io) under [Settings > Auth flow > Link](https://app.codat.io/settings/link-settings/onboarding) to let authenticated users view and manage their existing connections. You can also customize the title and subtitle shown on the manage connections screen.
 
    ![The Manage connections setting in the Codat Portal's Link settings, with a toggle and customizable title and subtitle](/img/updates/manageconnection.png "Manage connections setting in the Codat Portal")
+
 2. **Register your domain** using the [Set CORS settings](/platform-api#/operations/set-cors-settings) endpoint so the component can make authenticated requests from your site.
 3. **Get a company access token.** Authenticated features require an access token, retrieved server-side from the [Get company access token](/platform-api#/operations/get-company-access-token) endpoint (`GET /companies/{companyId}/accessToken`). Tokens are valid for 24 hours and scoped to a single company.
 4. **Pass the token to the Link SDK** via the `accessToken` prop when initializing the component.


### PR DESCRIPTION
Follow-up to #1880.

## 1. Remove the obsolete Hosted Link prerequisite

Removes the **If using Hosted Link** subsection from [`updates/250110-secure-linking`](https://docs.codat.io/updates/250110-secure-linking/):

> As a prerequisite to enabling one-time Link URLs, you also need to enable the new Hosted Link interface.

The [legacy Hosted Link UI was deprecated on 10 April 2025](https://docs.codat.io/updates/250110-deprecation-legacy-hosted-link-ui), so the new Hosted Link interface is the only interface available. Calling it out as a prerequisite implies there is still a choice to make, and sends readers to an update page they do not need to act on.

The **If using Hosted Link or your own custom-built Link UI** subsection immediately below already covers what those users need to check, so nothing is lost.

Also rewords that heading from "If using Hosted or build-your-own Link" to "If using Hosted Link or your own custom-built Link UI".

## 2. Unbreak main - Prettier formatting fix

`blog/260812-link-manage-connections-reconnect.md` landed on main via #1879 missing a blank line after the image inside the numbered list. That fails the `markdown-format` check, so **main is currently red** and every open PR inherits the failure.

Verified on a clean main checkout, with none of this PR involved:

```
$ git checkout main && git pull
$ npx prettier --check blog/260812-link-manage-connections-reconnect.md
[warn] blog/260812-link-manage-connections-reconnect.md
```

The fix is one blank line, formatting only, no content change. Included here to unblock this PR and main together.

## Note

`blog/250110-deprecation-legacy-hosted-link-ui.md` still says "Contact your Codat account manager with the request to enable the new Hosted Link flow", which is stale for the same reason as section 1. Left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)