### PR TITLE
Bump actions/setup-node from 6 to 7

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/check-markdown-lint.yml
+++ b/.github/workflows/check-markdown-lint.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/check-spelling.yml
+++ b/.github/workflows/check-spelling.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
           # build ships LFS pointer files instead of the actual binaries
           lfs: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -144,7 +144,7 @@ jobs:
           # the checkout is only needed so the action can push to gh-pages
           lfs: ${{ github.event.action != 'closed' }}
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         if: github.event.action != 'closed'
         with:
           node-version: 24


### PR DESCRIPTION
Recreates #1876 on an in-repo branch so CI can actually authenticate.

### Why #1876 can't pass

Dependabot-triggered runs resolve `secrets.*` from the **Dependabot** secret store, not the **Actions** store. `ADO_NPM_FEED_TOKEN` isn't reaching the runner from there, so the auth step wrote a blank `_password` into `~/.npmrc` and every job running `npm ci` died with:

```
npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

The repo `.npmrc` sets `registry=` to the codat-npm ADO feed for *all* packages, so a missing credential breaks the entire install rather than just `@codat/sdk-link-types`. `spell-check` was the only green check because it does `npm install -g cspell` from public npmjs and never touches the feed.

Confirmed by rerunning #1876's failed jobs today — still E401, still `actor=dependabot[bot]`.

### The bump is sound

On #1876's branch the `Setup Node.js` step (i.e. `setup-node@v7`) **succeeded**, npm cache included; only the following install step failed. This branch carries the identical 5-line change, off current `main`.

### Still outstanding

This unblocks the bump but not the cause — the Dependabot copy of `ADO_NPM_FEED_TOKEN` needs setting to the current base64 value, or the next Dependabot PR here fails the same way.

Closes #1876.

_— Raised by Claude on Phil's behalf_
