### PR TITLE
docs(sage50): remove support-enablement steps from the restart page

### DIFF
--- a/docs/integrations/accounting/sage50/restart-the-sage-50-connector.md
+++ b/docs/integrations/accounting/sage50/restart-the-sage-50-connector.md
@@ -1,13 +1,13 @@
 ---
 title: "Restart the Sage 50 Accounts Connector"
 slug: "restart-the-sage-50-connector"
-description: "How to enable and use the restart button on a Sage 50 Accounts Connector."
+description: "How to use the restart button on a Sage 50 Accounts Connector."
 sidebar_label: Restart the connector
 ---
 
 In some circumstances, your users might want to restart their Sage 50 Accounts Connector. For example, they might have syncs in progress that were interrupted by a technical issue.
 
-The **Restart connector** link in the connector UI is disabled by default. Codat Support can enable the link to allow your users to restart the connector, if needed.
+The **Restart connector** link is available in the connector UI to all of your users, and doesn't need to be enabled.
 
 If restarted, the connector automatically:
 
@@ -15,13 +15,11 @@ If restarted, the connector automatically:
 - Shuts down the connector.
 - Restarts the connector.
 
-## Enable the restart connector link
+## Use the restart connector link
 
-Codat's Support team needs to enable the **Restart connector** link for your user. To do so, they'll need the ID of the user's connector.
+Instructions for customers to find and use the **Restart connector** link.
 
-To obtain the connector ID from your user, please ask them to:
-
-1. Open their Sage 50 Accounts Connector.
+1. Open the Sage 50 Accounts Connector.
 2. Select the **About** link at the bottom of the connector window.
 
 <img
@@ -29,23 +27,6 @@ To obtain the connector ID from your user, please ask them to:
   alt="Sage 50 Accounts Connector window showing the About link highlighted."
 />
 
-3. Select the **Copy** icon next to the **Connector Id**.
-
-<img
-  src="/img/old/5caa5e0-Restart_connector_-_Copy_button.jpg"
-  alt="Copy icon highlighted next to the user's connector ID."
-/>
-
-4. Paste their connector ID into a document or email and send it to you.
-
-You can then send the connector ID to the Codat Support team by raising a ticket through the [support request form](https://codat.zendesk.com/hc/en-gb/requests/new). They will confirm when the **Restart connector** link has been enabled.
-
-## Use the restart connector link
-
-Instructions for customers to find and use the **Restart connector** link.
-
-1. Open the Sage 50 Accounts Connector.
-2. Select **About**.
 3. Select **Restart connector**.
 
 <img


### PR DESCRIPTION
## What

Rewrites the Sage 50 restart page so it just explains how to restart the connector. The **Enable the restart connector link** section (get the connector ID from your user → raise a support ticket → Support enables it) is gone, along with the connector-ID screenshot.

## Why

The page told customers the **Restart connector** link is "disabled by default" and has to be turned on per-connector by Codat Support. That's no longer true in the code:

- The link lives in the shared connector SDK's About overlay — `Codat.Connector.UI.WPF/Overlays.xaml` binds the hyperlink straight to `RestartConnectorCommand` with no visibility or enablement condition, and `AboutConnectorViewModel` has no gate either.
- `connector-sage50` never reads the per-connector `allowRestart` setting; its only feature gating (`IFeatureServiceStorage`, fed by `EnabledFeatures` on the pending-actions poll) is used for an invoice push feature.
- `sage50-service` still stores and serves the `allowRestart` setting (`connectorSettings` table, partition `sage50`), but nothing in it branches on the value. `RestartRequested` on pending-actions comes from the `connectors-api` `remoteRestarts` endpoint — that's the admin-triggered remote restart, not this toggle.

So the toggle only survived in the docs and some stale table rows. The original ask (Feb 2023) was that publicly documenting a support-enabled restart made the connector look unreliable.

## Acceptance criteria

| AC | Status |
| --- | --- |
| 1. Connector keeps its place in the About sections | Already true — the restart link is in the About overlay for all connectors |
| 2. Public docs updated or removed | This PR |
| 3. New connector can restart from the UI | Already true — link is unconditional at HEAD |
| 4. Connector without restart enabled gets it on update | Already true — no gate to satisfy |
| 5. Connector with restart enabled keeps it on update | Already true — the setting is ignored either way |

## Checks

- `prettier --check` on the changed file: clean
- `cspell` on the changed file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
