### PR TITLE
Document money.sage.com redirect host for Sage Bank Feeds client-hosted auth apps

### DIFF
--- a/blog/260902-sage-bank-feeds-money-sage-redirect.md
+++ b/blog/260902-sage-bank-feeds-money-sage-redirect.md
@@ -1,0 +1,31 @@
+---
+title: "Sage Bank Feeds: new money.sage.com redirect host for client-hosted auth apps"
+date: "2026-09-02"
+tags: ["Product", "Update"]
+authors: Huweey
+---
+
+Sage Banking V2 redirects users to `money.sage.com` at the end of the [Sage Bank Feeds](/integrations/bank-feeds/sage-bank-feeds/) connection flow. If you authenticate users through your own web app and that app checks the redirect host, you need to update it.
+
+<!--truncate-->
+
+## What's changing
+
+On **August 7, 2026**, Sage released its Banking V2 onboarding flow. The `redirectUri` that Sage passes to your web app can now point to `money.sage.com`. The existing `*.sagebankdrive.com` hosts remain in use, so your app will see both.
+
+Codat's own authorization UI needs no change. If you use it, no action is needed.
+
+## Action required
+
+This affects you only if you [authenticate users through your own web app](/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app) for Sage Bank Feeds. Check how your app handles the `redirectUri` query parameter that Sage supplies:
+
+- If your app validates or hard-codes the redirect host, allow `money.sage.com` alongside the existing hosts, or remove the check and use the `redirectUri` value exactly as supplied.
+- When you add the `state` query parameter, handle a `redirectUri` that already contains a query string by appending `&state={authId}` rather than `?state={authId}`.
+
+Your `Content-Security-Policy` header does not need to change. The `https://*.sage.com` entry already covers `money.sage.com`.
+
+## Expected impact if no action is taken
+
+If your app rejects or rewrites redirects to `money.sage.com`, users on Sage Banking V2 will not complete the connection after authenticating with your app. Connections using the existing hosts are unaffected.
+
+Contact [Codat Support](mailto:support@codat.io) if you have any questions.

--- a/blog/260902-sage-bank-feeds-money-sage-redirect.md
+++ b/blog/260902-sage-bank-feeds-money-sage-redirect.md
@@ -17,10 +17,7 @@ Codat's own authorization UI needs no change. If you use it, no action is needed
 
 ## Action required
 
-This affects you only if you [authenticate users through your own web app](/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app) for Sage Bank Feeds. Check how your app handles the `redirectUri` query parameter that Sage supplies:
-
-- If your app validates or hard-codes the redirect host, allow `money.sage.com` alongside the existing hosts, or remove the check and use the `redirectUri` value exactly as supplied.
-- When you add the `state` query parameter, handle a `redirectUri` that already contains a query string by appending `&state={authId}` rather than `?state={authId}`.
+This affects you only if you [authenticate users through your own web app](/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app) for Sage Bank Feeds. Check how your app handles the `redirectUri` query parameter that Sage supplies. If your app validates or hard-codes the redirect host, allow `money.sage.com` alongside the existing hosts, or remove the check and use the `redirectUri` value exactly as supplied, adding only the `state` query parameter.
 
 Your `Content-Security-Policy` header does not need to change. The `https://*.sage.com` entry already covers `money.sage.com`.
 

--- a/cspell.json
+++ b/cspell.json
@@ -248,6 +248,7 @@
     "yzth",
     "Zettle",
     "zpqy",
-    "zsth"
+    "zsth",
+    "sagebankdrive"
   ]
 }

--- a/docs/bank-feeds/integrations/sage/mapping.md
+++ b/docs/bank-feeds/integrations/sage/mapping.md
@@ -77,7 +77,7 @@ https://{authorizationRedirectUrl}?authorizationId={authId}&redirectUri={redirec
 
 1.  The `authorizationRedirectUrl` is the web app URL that you configured in the Codat Portal for the Sage Bank Feeds integration.
 2.  The `authId` is the unique authorization identifier for the company, this will be supplied by Sage and will be required when creating the dataconnection.
-3.  The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app, this will also be supplied by Sage. Its host varies by Sage product, region, and environment.
+3.  The `redirectUri` is the URI your web app redirects the SMB user to after authentication. Sage also supplies this value, and its host varies by Sage product, region, and environment.
 
 :::note Redirect host
 Sage controls the redirect host and can add new ones. Sage Banking V2, released in August 2026, redirects users to `money.sage.com`. The previous `*.sagebankdrive.com` hosts remain in use. If your web app checks or hard-codes the redirect host, update it to accept `money.sage.com`, or remove the check and use the `redirectUri` value exactly as supplied.

--- a/docs/bank-feeds/integrations/sage/mapping.md
+++ b/docs/bank-feeds/integrations/sage/mapping.md
@@ -135,8 +135,8 @@ If your request responds with a `200` response status code, the next step is to 
 
 // Examples:
 
-https://snd01eu.sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
-https://money.sage.com/{path-supplied-by-sage}?state=1122-3344-5566-7788
+https://snd01eu.sagebankdrive.com/...?state=1122-3344-5566-7788
+https://money.sage.com/...?state=1122-3344-5566-7788
 ```
 
 ### Establish the bank feed

--- a/docs/bank-feeds/integrations/sage/mapping.md
+++ b/docs/bank-feeds/integrations/sage/mapping.md
@@ -128,7 +128,7 @@ Sample request body:
 
 </Tabs>
 
-If your request responds with a `200` response status code, the next step is to redirect the company to the given `redirectUri`, adding the `authId` as the `state` query parameter. Use the `redirectUri` exactly as Sage supplied it. If it already contains a query string, append `&state={authId}` instead of `?state={authId}`.
+If your request responds with a `200` response status code, the next step is to redirect the company to the `redirectUri` exactly as Sage supplied it, adding the `authId` as the `state` query parameter.
 
 ```
 {redirectUri}?state={authId}

--- a/docs/bank-feeds/integrations/sage/mapping.md
+++ b/docs/bank-feeds/integrations/sage/mapping.md
@@ -77,7 +77,11 @@ https://{authorizationRedirectUrl}?authorizationId={authId}&redirectUri={redirec
 
 1.  The `authorizationRedirectUrl` is the web app URL that you configured in the Codat Portal for the Sage Bank Feeds integration.
 2.  The `authId` is the unique authorization identifier for the company, this will be supplied by Sage and will be required when creating the dataconnection.
-3.  The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app, this will also be supplied by Sage.
+3.  The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app, this will also be supplied by Sage. Its host varies by Sage product, region, and environment.
+
+:::note Redirect host
+Sage controls the redirect host and can add new ones. Sage Banking V2, released in August 2026, redirects users to `money.sage.com`. The previous `*.sagebankdrive.com` hosts remain in use. If your web app checks or hard-codes the redirect host, update it to accept `money.sage.com`, or remove the check and use the `redirectUri` value exactly as supplied.
+:::
 
 ## Hosted login page
 
@@ -124,14 +128,15 @@ Sample request body:
 
 </Tabs>
 
-If your request responds with a `200` response status code, the next step is to redirect the company to the given `redirectUri`, appending the `authId` as a query parameter.
+If your request responds with a `200` response status code, the next step is to redirect the company to the given `redirectUri`, adding the `authId` as the `state` query parameter. Use the `redirectUri` exactly as Sage supplied it. If it already contains a query string, append `&state={authId}` instead of `?state={authId}`.
 
 ```
 {redirectUri}?state={authId}
 
-// Example:
+// Examples:
 
-redirect_uri=https://snd01eu.Sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
+https://snd01eu.sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
+https://money.sage.com/{path-supplied-by-sage}?state=1122-3344-5566-7788
 ```
 
 ### Establish the bank feed

--- a/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
+++ b/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
@@ -55,8 +55,12 @@ There are two authentication flows between Sage, Codat's Sage Bank Feeds integra
 
    1. The `authorizationRedirectUrl` is the web app URL that you configured in the Codat Portal.
    2. The `authId` is the unique authorization identifier for the company.
-   3. The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app (see step two in the next procedure).
+   3. The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app (see step two in the next procedure). Sage supplies this value, and its host varies by Sage product, region, and environment.
    4. The `bankId` is a unique Id that represents the bank the SMB has attempted to link to in Sage (this will be a bank representing your organization).
+
+   :::note Redirect host
+   Sage controls the redirect host and can add new ones. Sage Banking V2, released in August 2026, redirects users to `money.sage.com`. The previous `*.sagebankdrive.com` hosts remain in use. If your web app checks or hard-codes the redirect host, update it to accept `money.sage.com`, or remove the check and use the `redirectUri` value exactly as supplied.
+   :::
 
 6. As configured in your web app, the user is redirected to a login or user authorization page.
 
@@ -88,14 +92,15 @@ You must include the "Content-Security-Policy" header with a value of `frame-anc
    }
    ```
 
-2. If the `PUT /authorization` request returns a 200 response, your web app should redirect the SMB user to the `redirectUri` for the Company, with the `authId` appended as a query parameter:
+2. If the `PUT /authorization` request returns a 200 response, your web app should redirect the SMB user to the `redirectUri` for the Company, with the `authId` added as the `state` query parameter. Use the `redirectUri` exactly as Sage supplied it. If it already contains a query string, append `&state={authId}` instead of `?state={authId}`.
 
    ```http
    {redirectUri}?state={authId}
 
-   // example:
+   // examples:
 
-   redirect_uri=https://snd01eu.sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
+   https://snd01eu.sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
+   https://money.sage.com/{path-supplied-by-sage}?state=1122-3344-5566-7788
    ```
 
 3. If the SMB user was successfully authenticated with Codat, Sage displays a dialog listing the available source bank accounts&mdash;the bank account in your application that will send bank feeds. For example:

--- a/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
+++ b/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
@@ -99,8 +99,8 @@ You must include the "Content-Security-Policy" header with a value of `frame-anc
 
    // examples:
 
-   https://snd01eu.sagebankdrive.com/api/v1/indirectredirect/11111-22222-33333-88888-9999?state=1122-3344-5566-7788
-   https://money.sage.com/{path-supplied-by-sage}?state=1122-3344-5566-7788
+   https://snd01eu.sagebankdrive.com/...?state=1122-3344-5566-7788
+   https://money.sage.com/...?state=1122-3344-5566-7788
    ```
 
 3. If the SMB user was successfully authenticated with Codat, Sage displays a dialog listing the available source bank accounts&mdash;the bank account in your application that will send bank feeds. For example:

--- a/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
+++ b/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
@@ -55,7 +55,7 @@ There are two authentication flows between Sage, Codat's Sage Bank Feeds integra
 
    1. The `authorizationRedirectUrl` is the web app URL that you configured in the Codat Portal.
    2. The `authId` is the unique authorization identifier for the company.
-   3. The `redirectUri` is the URI the SMB user will be redirected to after authentication through your web app (see step two in the next procedure). Sage supplies this value, and its host varies by Sage product, region, and environment.
+   3. The `redirectUri` is the URI your web app redirects the SMB user to after authentication, as described in step two of the next procedure. Sage supplies this value, and its host varies by Sage product, region, and environment.
    4. The `bankId` is a unique Id that represents the bank the SMB has attempted to link to in Sage (this will be a bank representing your organization).
 
    :::note Redirect host

--- a/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
+++ b/docs/integrations/bank-feeds/sage-bank-feeds/sage-bank-feeds-authenticate-users-web-app.md
@@ -92,7 +92,7 @@ You must include the "Content-Security-Policy" header with a value of `frame-anc
    }
    ```
 
-2. If the `PUT /authorization` request returns a 200 response, your web app should redirect the SMB user to the `redirectUri` for the Company, with the `authId` added as the `state` query parameter. Use the `redirectUri` exactly as Sage supplied it. If it already contains a query string, append `&state={authId}` instead of `?state={authId}`.
+2. If the `PUT /authorization` request returns a 200 response, your web app should redirect the SMB user to the `redirectUri` exactly as Sage supplied it, with the `authId` added as the `state` query parameter:
 
    ```http
    {redirectUri}?state={authId}


### PR DESCRIPTION
# Description

Sage's Banking V2 onboarding flow (released 7 August 2026) redirects users to `money.sage.com` at the end of the Sage Bank Feeds connection journey, alongside the existing `*.sagebankdrive.com` hosts. Clients who host their own auth web app and hard-code the redirect host may break.

- Both client-hosted auth pages now say the redirect host varies, name `money.sage.com`, and tell clients to use `redirectUri` as supplied and add `state` correctly when a query string is already present.
- Adds an update post so we have a dated reference to share with affected clients.
- Adds `sagebankdrive` to the cspell dictionary.

Codat's own authorization UI needs no change.

## Type of change

- [x] New document(s)/updating existing
